### PR TITLE
CI and release workflow updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,12 @@ on:
     types: [opened, reopened]
   push:
 
-permissions:
-  contents: read
-  packages: read
-
 jobs:
   build-gradle:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on:  ubuntu-latest
+    outputs:
+      code-version: ${{ steps.extract.outputs.CODE_VERSION }}
     steps:
       - name: Checkout project sources
         uses: actions/checkout@v4
@@ -28,11 +26,14 @@ jobs:
           arguments: build --full-stacktrace
         env:
           CI: true
+      - id: extract
+        name: Extract code version from gradle.properties
+        run: echo "CODE_VERSION=$(awk -F= '$1~/version/{print $2}' gradle.properties)" >> $GITHUB_OUTPUT
 
   publish-to-sonatype-snapshot:
     name: Publish to sonatype.org (SNAPSHOT)
     needs: [ build-gradle ]
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release')) &&  github.repository_owner == 'eu-digital-identity-wallet'
+    if: github.event_name != 'pull_request' && endsWith(needs.build-gradle.outputs.code-version, '-SNAPSHOT') && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release')) &&  github.repository_owner == 'eu-digital-identity-wallet'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,22 @@ on:
   release:
     types: [released]
 jobs:
+  extract-code-version:
+    name: Extract code version
+    runs-on: ubuntu-latest
+    outputs:
+      code-version: ${{ steps.extract.outputs.CODE_VERSION }}
+    steps:
+      - name: Checkout project sources
+        uses: actions/checkout@v4
+      - id: extract
+        name: Extract code version from gradle.properties
+        run: echo "CODE_VERSION=$(awk -F= '$1~/version/{print $2}' gradle.properties)" >> $GITHUB_OUTPUT
 
   publish-to-sonatype:
     name: Publish to sonatype.org
-    if: github.repository_owner == 'eu-digital-identity-wallet' && startsWith(github.ref, 'refs/tags')
+    needs: [ extract-code-version ]
+    if: github.repository_owner == 'eu-digital-identity-wallet' && startsWith(github.ref, 'refs/tags') && format('v{0}', needs.extract-code-version.outputs.code-version) == github.ref_name
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
- On CI workflow code version is extracted from gradle.properties and publish-to-sonatype-snapshot job is executed when this version ends with '-SNAPSHOT'
- On release workflow publication to maven is happening only if released tag is matching code version as set in gradle.properties file