### PR TITLE
Example to use azure verifier endpoint

### DIFF
--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
@@ -51,7 +51,7 @@ import javax.net.ssl.X509TrustManager
  * https://github.com/eu-digital-identity-wallet/eudi-srv-web-verifier-endpoint-23220-4-kt
  */
 fun main(): Unit = runBlocking {
-    val verifierApi = URL("http://localhost:8080")
+    val verifierApi = URL("https://dev.verifier-backend.eudiw.dev")
     val walletKeyPair = SiopIdTokenBuilder.randomKey()
     val wallet = Wallet(
         walletKeyPair = walletKeyPair,


### PR DESCRIPTION
This PR change the Example that demonstrates the usage of the lib.
In particular, a verifier endpoint deployed in azure is being used https://dev.verifier-backend.eudiw.dev