### PR TITLE
Properly base64-url-encode 'apv' header in JARM.

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/JarmJwt.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/JarmJwt.kt
@@ -83,7 +83,7 @@ private fun SiopOpenId4VPConfig.encrypt(
     val (jweAlgorithm, encryptionMethod, encryptionKeySet) = requirement
     val jweEncrypter = keyAndEncryptor(jweAlgorithm, encryptionKeySet)
     val jweHeader = JWEHeader.Builder(jweAlgorithm, encryptionMethod)
-        .agreementPartyVInfo(Base64URL(data.nonce))
+        .agreementPartyVInfo(Base64URL.encode(data.nonce))
         .build()
 
     val claimSet = JwtPayloadFactory.encryptedJwtClaimSet(data)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
@@ -211,6 +211,8 @@ class DefaultDispatcherTest {
 
                 val dispatcher = Wallet.createDispatcherWithVerifierAsserting(redirectUri) { responseParam ->
                     val encryptedJwt = responseParam.assertIsJwtEncryptedWithVerifiersPubKey()
+                    val apv = assertNotNull(encryptedJwt.header.agreementPartyVInfo)
+                    assertEquals(verifierRequest.nonce, apv.decodeToString())
                     val jwtClaimSet = encryptedJwt.jwtClaimsSet
                     assertEquals(vpTokenConsensus.vpToken, jwtClaimSet.getClaim("vp_token"))
                 }
@@ -239,6 +241,7 @@ class DefaultDispatcherTest {
 
                 val dispatcher = Wallet.createDispatcherWithVerifierAsserting(redirectUri) { responseParam ->
                     val encryptedJwt = responseParam.assertIsJwtEncryptedWithVerifiersPubKey()
+                    assertNull(encryptedJwt.header.agreementPartyVInfo)
                     val jwtClaimsSet = encryptedJwt.payload.toSignedJWT().assertIsSignedByWallet()
                     assertEquals(Wallet.config.issuer?.value, jwtClaimsSet.issuer)
                     assertContains(jwtClaimsSet.audience, Verifier.CLIENT_ID)
@@ -270,6 +273,7 @@ class DefaultDispatcherTest {
 
                     val dispatcher = Wallet.createDispatcherWithVerifierAsserting(redirectUri) { responseParam ->
                         val encryptedJwt = responseParam.assertIsJwtEncryptedWithVerifiersPubKey()
+                        assertNull(encryptedJwt.header.agreementPartyVInfo)
                         val jwtClaimsSet = encryptedJwt.payload.toSignedJWT().assertIsSignedByWallet()
                         assertEquals(Wallet.config.issuer?.value, jwtClaimsSet.issuer)
                         assertContains(jwtClaimsSet.audience, Verifier.CLIENT_ID)


### PR DESCRIPTION
Closes #232 