### PR TITLE
Support DID and verifier attesation schemes

### DIFF
--- a/Module.md
+++ b/Module.md
@@ -2,7 +2,7 @@
 
 The `eudi-lib-jvm-siop-openid4vp-kt` is a Kotlin library, targeting JVM, that supports
 the [SIOPv2 (draft 12)](https://openid.bitbucket.io/connect/openid-connect-self-issued-v2-1_0.html)
-and [OpenId4VP (draft 19)](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html) protocols.
+and [OpenId4VP (draft 20)](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html) protocols.
 In particular, the library focus on the wallet's role using those two protocols with constraints
 included in ISO 23220-4 and ISO-18013-7
 
@@ -115,7 +115,9 @@ Library requires the presence of `client_id_scheme` with one of the following va
 - `x509-san-dns` where verifier must send the authorization request signed (JAR) using by a suitable X509 certificate
 - `x509-san-uri` where verifier must send the authorization request signed (JAR) using by a suitable X509 certificate
 - `redirect_uri` where verifier must send the authorization request in plain (JAR cannot be used)
--
+- `did` where verifier must send the authorization request signed (JAR) using a key resolvable via DID URL.
+- `verifier_attestation` where verifier must send the authorization request signed (JAR), witch contains a verifier attestation JWT from a trusted issuer
+
 ### Authorization Request encoding
 
 OAUTH2 foresees that `AuthorizationRequest` is encoded as an HTTP GET

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ the [EUDI Wallet Reference Implementation project description](https://github.co
 
 This is a Kotlin library, targeting JVM, that supports 
 the [SIOPv2 (draft 12)](https://openid.bitbucket.io/connect/openid-connect-self-issued-v2-1_0.html) 
-and [OpenId4VP (draft 19)](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html) protocols.
+and [OpenId4VP (draft 20)](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html) protocols.
 In particular, the library focus on the wallet's role using those two protocols with constraints
 included in ISO 23220-4 and ISO-18013-7
 
@@ -171,7 +171,9 @@ Library requires the presence of `client_id_scheme` with one of the following va
 - `x509-san-dns` where verifier must send the authorization request signed (JAR) using by a suitable X509 certificate
 - `x509-san-uri` where verifier must send the authorization request signed (JAR) using by a suitable X509 certificate
 - `redirect_uri` where verifier must send the authorization request in plain (JAR cannot be used)
--
+- `did` where verifier must send the authorization request signed (JAR) using a key resolvable via DID URL.
+- `verifier_attestation` where verifier must send the authorization request signed (JAR), witch contains a verifier attestation JWT from a trusted issuer
+
 ### Authorization Request encoding
 
 OAUTH2 foresees that `AuthorizationRequest` is encoded as an HTTP GET

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.parallel=true
 
 # Project properties
 group=eu.europa.ec.eudi
-version=0.3.6-SNAPSHOT
+version=0.4.0-SNAPSHOT
 
 # Sonar
 systemProp.sonar.gradle.skipCompile=true

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
@@ -34,7 +34,7 @@ sealed interface Client : Serializable {
     data class RedirectUri(val clientId: URI) : Client
     data class X509SanDns(val clientId: String, val cert: X509Certificate) : Client
     data class X509SanUri(val clientId: URI, val cert: X509Certificate) : Client
-    data class DIDClient(val clientId: DID) : Client
+    data class DIDClient(val clientId: URI) : Client
 
     /**
      * The id of the client.
@@ -264,6 +264,8 @@ sealed interface RequestValidationError : AuthorizationRequestError {
     data class InvalidClientIdScheme(val value: String) : RequestValidationError
 
     data class InvalidIdTokenType(val value: String) : RequestValidationError
+
+    data class DIDResolutionFailed(val didUrl: String) : RequestValidationError
 }
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
@@ -35,6 +35,7 @@ sealed interface Client : Serializable {
     data class X509SanDns(val clientId: String, val cert: X509Certificate) : Client
     data class X509SanUri(val clientId: URI, val cert: X509Certificate) : Client
     data class DIDClient(val clientId: URI) : Client
+    data class Attested(val clientId: String) : Client
 
     /**
      * The id of the client.
@@ -46,6 +47,7 @@ sealed interface Client : Serializable {
             is X509SanDns -> clientId
             is X509SanUri -> clientId.toString()
             is DIDClient -> clientId.toString()
+            is Attested -> clientId
         }
 }
 
@@ -72,6 +74,7 @@ fun Client.legalName(legalName: X509Certificate.() -> String? = X509Certificate:
         is X509SanDns -> cert.legalName()
         is X509SanUri -> cert.legalName()
         is DIDClient -> null
+        is Attested -> null
     }
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
@@ -34,6 +34,7 @@ sealed interface Client : Serializable {
     data class RedirectUri(val clientId: URI) : Client
     data class X509SanDns(val clientId: String, val cert: X509Certificate) : Client
     data class X509SanUri(val clientId: URI, val cert: X509Certificate) : Client
+    data class DIDClient(val clientId: DID) : Client
 
     /**
      * The id of the client.
@@ -44,11 +45,12 @@ sealed interface Client : Serializable {
             is RedirectUri -> clientId.toString()
             is X509SanDns -> clientId
             is X509SanUri -> clientId.toString()
+            is DIDClient -> clientId.toString()
         }
 }
 
 /**
- * Gets the legal name (i.e. CN) from this [X509Certificate].
+ * Gets the legal name (i.e., CN) from this [X509Certificate].
  */
 fun X509Certificate.legalName(): String? {
     val distinguishedName = X500Name(subjectX500Principal.name)
@@ -69,6 +71,7 @@ fun Client.legalName(legalName: X509Certificate.() -> String? = X509Certificate:
         is RedirectUri -> null
         is X509SanDns -> cert.legalName()
         is X509SanUri -> cert.legalName()
+        is DIDClient -> null
     }
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -58,7 +58,7 @@ fun interface X509CertificateTrust {
     fun isTrusted(chain: List<X509Certificate>): Boolean
 }
 
-interface LookupPublicKeyByDIDUrl {
+fun interface LookupPublicKeyByDIDUrl {
     suspend fun resolveKey(didUrl: URI): PublicKey?
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -122,8 +122,12 @@ sealed interface SupportedClientIdScheme {
      * header a Verifier Attestation JWT under `jwt` claim
      *
      * @param trust a function for verifying the digital signature of the Verifier Attestation JWT.
+     * @param clockSkew clockSkew between wallet and attestation issuer
      */
-    data class VerifierAttestation(val trust: JWSVerifier) : SupportedClientIdScheme
+    data class VerifierAttestation(
+        val trust: JWSVerifier,
+        val clockSkew: Duration = Duration.ofSeconds(10),
+    ) : SupportedClientIdScheme
 
     fun scheme(): ClientIdScheme = when (this) {
         is DID -> ClientIdScheme.DID

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -15,11 +15,7 @@
  */
 package eu.europa.ec.eudi.openid4vp
 
-import com.nimbusds.jose.EncryptionMethod
-import com.nimbusds.jose.JWEAlgorithm
-import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.JWSSigner
-import com.nimbusds.jose.JWSVerifier
+import com.nimbusds.jose.*
 import com.nimbusds.jose.crypto.ECDSASigner
 import com.nimbusds.jose.crypto.RSASSASigner
 import com.nimbusds.jose.jwk.ECKey
@@ -32,6 +28,7 @@ import kotlinx.serialization.json.JsonObject
 import java.net.URI
 import java.security.PublicKey
 import java.security.cert.X509Certificate
+import java.time.Clock
 import java.time.Duration
 
 sealed interface JwkSetSource {
@@ -268,12 +265,14 @@ fun JarmConfiguration.encryptionConfig(): Encryption? = when (this) {
  * @param jarmConfiguration whether wallet supports JARM. If not specified, it takes the default value
  * [JarmConfiguration.NotSupported].
  * @param vpConfiguration options about OpenId4VP. If not provided, [VPConfiguration.Default] is being used.
+ * @param clock the system Clock
  * @param supportedClientIdSchemes the client id schemes that are supported/trusted by the wallet
  */
 data class SiopOpenId4VPConfig(
     val issuer: Issuer? = SelfIssued,
     val jarmConfiguration: JarmConfiguration = NotSupported,
     val vpConfiguration: VPConfiguration = VPConfiguration.Default,
+    val clock: Clock,
     val supportedClientIdSchemes: List<SupportedClientIdScheme>,
 ) {
     init {
@@ -284,8 +283,9 @@ data class SiopOpenId4VPConfig(
         issuer: Issuer? = SelfIssued,
         jarmConfiguration: JarmConfiguration = NotSupported,
         vpConfiguration: VPConfiguration = VPConfiguration.Default,
+        clock: Clock,
         vararg supportedClientIdSchemes: SupportedClientIdScheme,
-    ) : this(issuer, jarmConfiguration, vpConfiguration, supportedClientIdSchemes.toList())
+    ) : this(issuer, jarmConfiguration, vpConfiguration, clock, supportedClientIdSchemes.toList())
 
     companion object {
         /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -29,6 +29,7 @@ import eu.europa.ec.eudi.openid4vp.SiopOpenId4VPConfig.Companion.SelfIssued
 import eu.europa.ec.eudi.prex.PresentationDefinition
 import kotlinx.serialization.json.JsonObject
 import java.net.URI
+import java.security.PublicKey
 import java.security.cert.X509Certificate
 import java.time.Duration
 
@@ -54,6 +55,10 @@ data class PreregisteredClient(
 
 fun interface X509CertificateTrust {
     fun isTrusted(chain: List<X509Certificate>): Boolean
+}
+
+interface LookupPublicKeyByDIDUrl {
+    suspend fun resolveKey(didUrl: URI): PublicKey?
 }
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -127,6 +127,15 @@ sealed interface SupportedClientIdScheme {
      * @param trust a function for verifying the digital signature of the Verifier Attestation JWT.
      */
     data class VerifierAttestation(val trust: JWSVerifier) : SupportedClientIdScheme
+
+    fun scheme(): ClientIdScheme = when (this) {
+        is DID -> ClientIdScheme.DID
+        is Preregistered -> ClientIdScheme.PreRegistered
+        RedirectUri -> ClientIdScheme.RedirectUri
+        is VerifierAttestation -> ClientIdScheme.VERIFIER_ATTESTATION
+        is X509SanDns -> ClientIdScheme.X509_SAN_DNS
+        is X509SanUri -> ClientIdScheme.X509_SAN_URI
+    }
 }
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -290,9 +290,9 @@ data class SiopOpenId4VPConfig(
         jarmConfiguration: JarmConfiguration = NotSupported,
         vpConfiguration: VPConfiguration = VPConfiguration.Default,
         clock: Clock = Clock.systemDefaultZone(),
-        jarSkew: Duration = Duration.ofSeconds(15L),
+        jarClockSkew: Duration = Duration.ofSeconds(15L),
         vararg supportedClientIdSchemes: SupportedClientIdScheme,
-    ) : this(issuer, jarmConfiguration, vpConfiguration, clock, jarSkew, supportedClientIdSchemes.toList())
+    ) : this(issuer, jarmConfiguration, vpConfiguration, clock, jarClockSkew, supportedClientIdSchemes.toList())
 
     companion object {
         /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -295,15 +295,5 @@ data class SiopOpenId4VPConfig(
     }
 }
 
-internal fun SiopOpenId4VPConfig.supportedClientIdScheme(scheme: ClientIdScheme): SupportedClientIdScheme? {
-    fun SupportedClientIdScheme.scheme(): ClientIdScheme = when (this) {
-        is SupportedClientIdScheme.Preregistered -> ClientIdScheme.PreRegistered
-        is SupportedClientIdScheme.X509SanUri -> ClientIdScheme.X509_SAN_URI
-        is SupportedClientIdScheme.X509SanDns -> ClientIdScheme.X509_SAN_DNS
-        SupportedClientIdScheme.RedirectUri -> ClientIdScheme.RedirectUri
-        is SupportedClientIdScheme.DID -> ClientIdScheme.DID
-        is SupportedClientIdScheme.VerifierAttestation -> ClientIdScheme.VERIFIER_ATTESTATION
-    }
-
-    return supportedClientIdSchemes.firstOrNull { it.scheme() == scheme }
-}
+internal fun SiopOpenId4VPConfig.supportedClientIdScheme(scheme: ClientIdScheme): SupportedClientIdScheme? =
+    supportedClientIdSchemes.firstOrNull { it.scheme() == scheme }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -99,6 +99,8 @@ sealed interface SupportedClientIdScheme {
      * In this scheme, Verifier must NOT sign his request
      */
     data object RedirectUri : SupportedClientIdScheme
+
+    data class DID(val lookup: LookupPublicKeyByDIDUrl) : SupportedClientIdScheme
 }
 
 /**
@@ -264,6 +266,7 @@ internal fun SiopOpenId4VPConfig.supportedClientIdScheme(scheme: ClientIdScheme)
         is SupportedClientIdScheme.X509SanUri -> ClientIdScheme.X509_SAN_URI
         is SupportedClientIdScheme.X509SanDns -> ClientIdScheme.X509_SAN_DNS
         SupportedClientIdScheme.RedirectUri -> ClientIdScheme.RedirectUri
+        is SupportedClientIdScheme.DID -> ClientIdScheme.DID
     }
 
     return supportedClientIdSchemes.firstOrNull { it.scheme() == scheme }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -265,14 +265,14 @@ fun JarmConfiguration.encryptionConfig(): Encryption? = when (this) {
  * @param jarmConfiguration whether wallet supports JARM. If not specified, it takes the default value
  * [JarmConfiguration.NotSupported].
  * @param vpConfiguration options about OpenId4VP. If not provided, [VPConfiguration.Default] is being used.
- * @param clock the system Clock
+ * @param clock the system Clock. If not provided system's default clock will be used.
  * @param supportedClientIdSchemes the client id schemes that are supported/trusted by the wallet
  */
 data class SiopOpenId4VPConfig(
     val issuer: Issuer? = SelfIssued,
     val jarmConfiguration: JarmConfiguration = NotSupported,
     val vpConfiguration: VPConfiguration = VPConfiguration.Default,
-    val clock: Clock,
+    val clock: Clock = Clock.systemDefaultZone(),
     val supportedClientIdSchemes: List<SupportedClientIdScheme>,
 ) {
     init {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -122,11 +122,11 @@ sealed interface SupportedClientIdScheme {
      * header a Verifier Attestation JWT under `jwt` claim
      *
      * @param trust a function for verifying the digital signature of the Verifier Attestation JWT.
-     * @param clockSkew clockSkew between wallet and attestation issuer
+     * @param clockSkew max acceptable skew between wallet and attestation issuer
      */
     data class VerifierAttestation(
         val trust: JWSVerifier,
-        val clockSkew: Duration = Duration.ofSeconds(10),
+        val clockSkew: Duration = Duration.ofSeconds(15L),
     ) : SupportedClientIdScheme
 
     fun scheme(): ClientIdScheme = when (this) {
@@ -270,6 +270,7 @@ fun JarmConfiguration.encryptionConfig(): Encryption? = when (this) {
  * [JarmConfiguration.NotSupported].
  * @param vpConfiguration options about OpenId4VP. If not provided, [VPConfiguration.Default] is being used.
  * @param clock the system Clock. If not provided system's default clock will be used.
+ * @param jarClockSkew max acceptable skew between wallet and verifier
  * @param supportedClientIdSchemes the client id schemes that are supported/trusted by the wallet
  */
 data class SiopOpenId4VPConfig(
@@ -277,6 +278,7 @@ data class SiopOpenId4VPConfig(
     val jarmConfiguration: JarmConfiguration = NotSupported,
     val vpConfiguration: VPConfiguration = VPConfiguration.Default,
     val clock: Clock = Clock.systemDefaultZone(),
+    val jarClockSkew: Duration = Duration.ofSeconds(15L),
     val supportedClientIdSchemes: List<SupportedClientIdScheme>,
 ) {
     init {
@@ -287,9 +289,10 @@ data class SiopOpenId4VPConfig(
         issuer: Issuer? = SelfIssued,
         jarmConfiguration: JarmConfiguration = NotSupported,
         vpConfiguration: VPConfiguration = VPConfiguration.Default,
-        clock: Clock,
+        clock: Clock = Clock.systemDefaultZone(),
+        jarSkew: Duration = Duration.ofSeconds(15L),
         vararg supportedClientIdSchemes: SupportedClientIdScheme,
-    ) : this(issuer, jarmConfiguration, vpConfiguration, clock, supportedClientIdSchemes.toList())
+    ) : this(issuer, jarmConfiguration, vpConfiguration, clock, jarSkew, supportedClientIdSchemes.toList())
 
     companion object {
         /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/DID.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/DID.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vp
+
+import java.net.URI
+import java.security.PublicKey
+
+@JvmInline
+value class DIDUrl private constructor(val uri: URI) {
+    override fun toString(): String = uri.toString()
+
+    companion object {
+        fun parse(s: String): Result<DIDUrl> = runCatching {
+            val uri = URI.create(s)
+            require(uri.scheme == "did") { "Scheme should be did" }
+            require(uri.isAbsolute)
+            val (_, method, _) = s.split(":", limit = 3)
+            require(method.isNotEmpty())
+            DIDUrl(uri)
+        }
+    }
+}
+
+@JvmInline
+value class DID private constructor(val uri: URI) {
+
+    override fun toString(): String = uri.toString()
+
+    companion object {
+        fun parse(s: String): Result<DID> = runCatching {
+            val uri = URI.create(s)
+            require(uri.scheme == "did") { "Scheme should be did" }
+            require(uri.isAbsolute)
+            require(uri.path.isNullOrEmpty())
+            require(uri.fragment.isNullOrEmpty())
+            require(uri.query.isNullOrEmpty())
+            val (_, method, identifier) = s.split(":", limit = 3)
+            require(method.isNotEmpty())
+            require(identifier.isNotEmpty())
+            DID(uri)
+        }
+    }
+}
+
+typealias DIDMethod = String
+
+interface LookupPublicKeyByDIDUrl {
+    suspend fun resolveKey(didUrl: URI): PublicKey?
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticator.kt
@@ -235,6 +235,7 @@ private fun verifierAttestation(
     ensure(verifierAttestationClaimSet.sub == clientId) {
         invalidVerifierAttestationJwt("sub claim and authorization's request client_id don't match")
     }
+    // TODO check exp, iat, nbf
 
     return verifierAttestationClaimSet
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticator.kt
@@ -79,7 +79,7 @@ internal class RequestAuthenticator(siopOpenId4VPConfig: SiopOpenId4VPConfig, ht
     }
 }
 
-private class ClientAuthenticator(private val siopOpenId4VPConfig: SiopOpenId4VPConfig) {
+internal class ClientAuthenticator(private val siopOpenId4VPConfig: SiopOpenId4VPConfig) {
     suspend fun authenticateClient(request: FetchedRequest): AuthenticatedClient {
         val requestObject = when (request) {
             is FetchedRequest.JwtSecured -> request.jwt.requestObject()

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectResolver.kt
@@ -109,4 +109,5 @@ private fun AuthenticatedClient.toClient(): Client =
         is AuthenticatedClient.X509SanDns -> Client.X509SanDns(clientId, chain[0])
         is AuthenticatedClient.X509SanUri -> Client.X509SanUri(clientId, chain[0])
         is AuthenticatedClient.DIDClient -> Client.DIDClient(client.uri)
+        is AuthenticatedClient.Attested -> Client.Attested(clientId)
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectResolver.kt
@@ -108,5 +108,5 @@ private fun AuthenticatedClient.toClient(): Client =
         is AuthenticatedClient.RedirectUri -> Client.RedirectUri(clientId)
         is AuthenticatedClient.X509SanDns -> Client.X509SanDns(clientId, chain[0])
         is AuthenticatedClient.X509SanUri -> Client.X509SanUri(clientId, chain[0])
-        is AuthenticatedClient.DIDClient -> Client.DIDClient(client)
+        is AuthenticatedClient.DIDClient -> Client.DIDClient(client.uri)
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectResolver.kt
@@ -108,4 +108,5 @@ private fun AuthenticatedClient.toClient(): Client =
         is AuthenticatedClient.RedirectUri -> Client.RedirectUri(clientId)
         is AuthenticatedClient.X509SanDns -> Client.X509SanDns(clientId, chain[0])
         is AuthenticatedClient.X509SanUri -> Client.X509SanUri(clientId, chain[0])
+        is AuthenticatedClient.DIDClient -> Client.DIDClient(client)
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectValidator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectValidator.kt
@@ -249,6 +249,8 @@ private fun requiredResponseMode(
         is AuthenticatedClient.RedirectUri -> ensure(client.clientId == uri) {
             UnsupportedResponseMode("$responseMode doesn't match ${client.clientId}").asException()
         }
+
+        is AuthenticatedClient.DIDClient -> Unit
     }
     return responseMode
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectValidator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectValidator.kt
@@ -251,6 +251,24 @@ private fun requiredResponseMode(
         }
 
         is AuthenticatedClient.DIDClient -> Unit
+
+        is AuthenticatedClient.Attested -> {
+            val allowedUris = when (responseMode) {
+                is ResponseMode.Query,
+                is ResponseMode.QueryJwt,
+                is ResponseMode.Fragment,
+                is ResponseMode.FragmentJwt,
+                -> client.claims.redirectUris
+                is ResponseMode.DirectPost,
+                is ResponseMode.DirectPostJwt,
+                -> client.claims.responseUris
+            }
+            if (!allowedUris.isNullOrEmpty()) {
+                ensure(uri.toString() in allowedUris) {
+                    UnsupportedResponseMode("$responseMode use a URI that is not included in attested URIs $allowedUris").asException()
+                }
+            }
+        }
     }
     return responseMode
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectValidator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectValidator.kt
@@ -231,7 +231,7 @@ private fun requiredResponseMode(
         "query" -> requiredRedirectUriAndNotProvidedResponseUri().let { ResponseMode.Query(it) }
         "query.jwt" -> requiredRedirectUriAndNotProvidedResponseUri().let { ResponseMode.QueryJwt(it) }
         null, "fragment" -> requiredRedirectUriAndNotProvidedResponseUri().let { ResponseMode.Fragment(it) }
-        "fragment.jwt" -> requiredRedirectUriAndNotProvidedResponseUri().let { ResponseMode.Fragment(it) }
+        "fragment.jwt" -> requiredRedirectUriAndNotProvidedResponseUri().let { ResponseMode.FragmentJwt(it) }
         else -> throw UnsupportedResponseMode(unvalidated.responseMode).asException()
     }
 
@@ -259,6 +259,7 @@ private fun requiredResponseMode(
                 is ResponseMode.Fragment,
                 is ResponseMode.FragmentJwt,
                 -> client.claims.redirectUris
+
                 is ResponseMode.DirectPost,
                 is ResponseMode.DirectPostJwt,
                 -> client.claims.responseUris

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationRequestErrorCode.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationRequestErrorCode.kt
@@ -98,6 +98,7 @@ internal enum class AuthorizationRequestErrorCode(val code: String) {
                 is UnableToFetchClientMetadata,
                 is UnableToFetchPresentationDefinition,
                 is UnableToFetchRequestObject,
+                is DIDResolutionFailed,
                 -> PROCESSING_FAILURE
             }
         }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
@@ -42,6 +42,7 @@ import java.net.URL
 import java.net.URLEncoder
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
+import java.time.Clock
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
@@ -378,6 +379,7 @@ private fun walletConfig(vararg supportedClientIdScheme: SupportedClientIdScheme
             supportedMethods = listOf(EncryptionMethod.A128CBC_HS256, EncryptionMethod.A256GCM),
         ),
         supportedClientIdSchemes = supportedClientIdScheme,
+        clock = Clock.systemDefaultZone(),
     )
 
 val PidPresentationDefinition = """

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
@@ -45,6 +45,7 @@ import java.net.URI
 import java.net.URLEncoder
 import java.security.KeyStore
 import java.security.cert.X509Certificate
+import java.time.Clock
 import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -98,6 +99,7 @@ class UnvalidatedRequestResolverTest {
             SupportedClientIdScheme.X509SanUri(::validateChain),
             SupportedClientIdScheme.RedirectUri,
         ),
+        clock = Clock.systemDefaultZone(),
     )
 
     private val resolver = DefaultAuthorizationRequestResolver(walletConfig, DefaultHttpClientFactory)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/DIDTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/DIDTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vp.internal
+
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class DIDTest {
+    private val sampleDidJwk =
+        """
+           did:jwk:
+           eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI
+           1Njpnc0w0VTRxX1J6VFhRckpwQUNnZGkwb1lCdUV1QjNZNWZFanhDd1NPUFlBIiwia3
+           R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImFsZyI6IkVTMzg0IiwieCI6ImEtRWV5T2hlR
+           UNWcDJqRkdVRTNqR0RCNlAzVV80S0lyZHRzTU9RQXFQN0NBMlVvV3NERG1nOWdJUVhi
+           OEthd0ciLCJ5Ijoib3cxWDJ6VFVRaG12elY4NnpHdGhKc0xLeDE2MmhmSmxmN1p0OTF
+           YUnZBTzRScE4zR2RGaVl3Tmc0NXJWUmlUcSJ9
+        """.trimIndent().replace("\n", "")
+
+    @Test
+    fun `valid should DIDs should be parsed`() {
+        listOf(
+            "did:ethr:mainnet:0x3b0bc51ab9de1e5b7b6e34e5b960285805c41736",
+            "did:dns:danubetech.com",
+            "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169",
+            "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme",
+            sampleDidJwk,
+            "did:ebsi:ziE2n8Ckhi6ut5Z8Cexrihd",
+        ).forEach {
+            assertNotNull(DID.parse(it).getOrNull(), "Failed to parse $it")
+        }
+    }
+
+    @Test
+    fun `invalid should DIDs should not be parsed`() {
+        listOf(
+            "didethr:mainnet:0x3b0bc51ab9de1e5b7b6e34e5b960285805c41736",
+            "dns:danubetech.com",
+            "did:   :zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme",
+            "did:jwk:   ",
+        ).forEach {
+            assertNull(DID.parse(it).getOrNull(), "Parsed should fail for $it")
+        }
+    }
+
+    @Test
+    fun `valid should DIDs should not be parsed as DIDURLs`() {
+        listOf(
+            "did:ethr:mainnet:0x3b0bc51ab9de1e5b7b6e34e5b960285805c41736",
+            "did:dns:danubetech.com",
+            "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169",
+            "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme",
+            sampleDidJwk,
+            "did:ebsi:ziE2n8Ckhi6ut5Z8Cexrihd",
+        ).forEach {
+            assertNull(AbsoluteDIDUrl.parse(it).getOrNull(), "Parsed should fail for $it")
+        }
+    }
+
+    @Test
+    fun `valid should DID URLSs should be parsed as DIDURLs`() {
+        listOf(
+            "did:ethr:mainnet:0x3b0bc51ab9de1e5b7b6e34e5b960285805c41736#controller",
+            "did:dns:danubetech.com#z6MkjvBkt8ETnxXGBFPSGgYKb43q7oNHLX8BiYSPcXVG6gY6",
+            "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169#zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169",
+            "did:ebsi:ziE2n8Ckhi6ut5Z8Cexrihd#key-1",
+        ).forEach {
+            assertNotNull(AbsoluteDIDUrl.parse(it).getOrNull(), "Failed to parse $it")
+        }
+    }
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/DIDTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/DIDTest.kt
@@ -40,6 +40,7 @@ class DIDTest {
             "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme",
             sampleDidJwk,
             "did:ebsi:ziE2n8Ckhi6ut5Z8Cexrihd",
+            "did:eosio:4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11:caleosblocks",
         ).forEach {
             assertNotNull(DID.parse(it).getOrNull(), "Failed to parse $it")
         }
@@ -52,6 +53,9 @@ class DIDTest {
             "dns:danubetech.com",
             "did:   :zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme",
             "did:jwk:   ",
+            "did:example:123?service=agent&relativeRef=/credentials#degree",
+            "did:example:123?service=agent&relativeRef=/credentials",
+            "did:eosio:4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11:caleosblocks#123",
         ).forEach {
             assertNull(DID.parse(it).getOrNull(), "Parsed should fail for $it")
         }
@@ -60,12 +64,12 @@ class DIDTest {
     @Test
     fun `valid should DIDs should not be parsed as DIDURLs`() {
         listOf(
-            "did:ethr:mainnet:0x3b0bc51ab9de1e5b7b6e34e5b960285805c41736",
             "did:dns:danubetech.com",
             "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169",
             "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme",
             sampleDidJwk,
             "did:ebsi:ziE2n8Ckhi6ut5Z8Cexrihd",
+            "did:ethr:mainnet:0x3b0bc51ab9de1e5b7b6e34e5b960285805c41736",
         ).forEach {
             assertNull(AbsoluteDIDUrl.parse(it).getOrNull(), "Parsed should fail for $it")
         }
@@ -78,6 +82,8 @@ class DIDTest {
             "did:dns:danubetech.com#z6MkjvBkt8ETnxXGBFPSGgYKb43q7oNHLX8BiYSPcXVG6gY6",
             "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169#zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169",
             "did:ebsi:ziE2n8Ckhi6ut5Z8Cexrihd#key-1",
+            "did:example:123?service=agent&relativeRef=/credentials#degree",
+            "did:eosio:4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11:caleosblocks#123",
         ).forEach {
             assertNotNull(AbsoluteDIDUrl.parse(it).getOrNull(), "Failed to parse $it")
         }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/AttestationIssuer.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/AttestationIssuer.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vp.internal.request
+
+import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.JWSVerifier
+import com.nimbusds.jose.crypto.factories.DefaultJWSSignerFactory
+import com.nimbusds.jose.crypto.factories.DefaultJWSVerifierFactory
+import com.nimbusds.jose.jwk.JWK
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import java.net.URI
+import java.time.Clock
+import java.time.Instant
+import java.util.*
+import kotlin.time.Duration.Companion.seconds
+
+object AttestationIssuer {
+    const val ID = "Attestation Issuer"
+    private val algAndKey by lazy { randomKey() }
+    private val attestationDuration = 10.seconds
+
+    val verifier: JWSVerifier by lazy {
+        val (alg, key) = algAndKey
+        val h = JWSHeader.Builder(alg).build()
+        DefaultJWSVerifierFactory().createJWSVerifier(h, key.toPublicKey())
+    }
+
+    fun attestation(
+        clock: Clock,
+        clientId: String,
+        clientPubKey: JWK,
+        redirectUris: List<URI>? = null,
+        responseUris: List<URI>? = null,
+    ): SignedJWT {
+        val (alg, key) = algAndKey
+        val signer = DefaultJWSSignerFactory().createJWSSigner(key, alg)
+        val header = JWSHeader.Builder(alg)
+            .type(JOSEObjectType("verifier-attestation+jwt"))
+            .build()
+        val now = clock.instant()
+        require(!clientPubKey.isPrivate) { "clientPubKey should be public" }
+        val cnf = mapOf("jwk" to clientPubKey.toPublicJWK().toJSONObject())
+        val claimSet = with(JWTClaimsSet.Builder()) {
+            issuer(ID)
+            subject(clientId)
+            issueTime(now.toDate())
+            expirationTime(expiration(now).toDate())
+            claim("cnf", cnf)
+            redirectUris?.let { uris -> claim("redirect_uris", uris.map { it.toString() }) }
+            responseUris?.let { uris -> claim("response_urls", uris.map { it.toString() }) }
+            build()
+        }
+
+        return SignedJWT(header, claimSet).apply { sign(signer) }
+    }
+
+    private fun expiration(iat: Instant) = iat.plusSeconds(attestationDuration.inWholeSeconds)
+
+    private fun Instant.toDate() = Date.from(this)
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticatorTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticatorTest.kt
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vp.internal.request
+
+import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.factories.DefaultJWSSignerFactory
+import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jose.jwk.JWK
+import com.nimbusds.jose.jwk.KeyUse
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import eu.europa.ec.eudi.openid4vp.*
+import eu.europa.ec.eudi.openid4vp.internal.AbsoluteDIDUrl
+import eu.europa.ec.eudi.openid4vp.internal.DID
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.assertThrows
+import java.net.URI
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class RequestAuthenticatorTest
+
+class ClientAuthenticatorTest {
+
+    @Test
+    fun `when client_id is missing, no authentication can be done`() = runTest {
+        val clientAuthenticator = ClientAuthenticator(
+            SiopOpenId4VPConfig(
+                jarmConfiguration = JarmConfiguration.NotSupported,
+                vpConfiguration = VPConfiguration(
+                    presentationDefinitionUriSupported = false,
+                    emptyMap(),
+                ),
+                supportedClientIdSchemes = listOf(
+                    SupportedClientIdScheme.RedirectUri,
+                ),
+            ),
+        )
+
+        val request = UnvalidatedRequestObject(clientId = null).plain()
+
+        assertFailsWithError<RequestValidationError.MissingClientId> {
+            clientAuthenticator.authenticateClient(request)
+        }
+    }
+
+    @Test
+    fun `when scheme is missing, no authentication can be done`() = runTest {
+        val clientAuthenticator = ClientAuthenticator(
+            SiopOpenId4VPConfig(
+                jarmConfiguration = JarmConfiguration.NotSupported,
+                vpConfiguration = VPConfiguration(
+                    presentationDefinitionUriSupported = false,
+                    emptyMap(),
+                ),
+                supportedClientIdSchemes = listOf(
+                    SupportedClientIdScheme.RedirectUri,
+                ),
+            ),
+        )
+
+        val request = UnvalidatedRequestObject(
+            clientId = "foo",
+            responseMode = null,
+        ).plain()
+
+        assertFailsWithError<RequestValidationError.InvalidClientIdScheme> {
+            clientAuthenticator.authenticateClient(request)
+        }
+    }
+
+    @Test
+    fun `when scheme is wrong, no authentication can be done`() = runTest {
+        val clientAuthenticator = ClientAuthenticator(
+            SiopOpenId4VPConfig(
+                jarmConfiguration = JarmConfiguration.NotSupported,
+                vpConfiguration = VPConfiguration(
+                    presentationDefinitionUriSupported = false,
+                    emptyMap(),
+                ),
+                supportedClientIdSchemes = listOf(
+                    SupportedClientIdScheme.RedirectUri,
+                ),
+            ),
+        )
+
+        val request = UnvalidatedRequestObject(
+            clientId = "foo",
+            responseMode = "bar",
+        ).plain()
+
+        assertFailsWithError<RequestValidationError.InvalidClientIdScheme> {
+            clientAuthenticator.authenticateClient(request)
+        }
+    }
+
+    @Test
+    fun `when scheme is redirect_uri, client_id is URI and request is not signed, we have authentication`() =
+        runTest {
+            val clientAuthenticator = ClientAuthenticator(
+                SiopOpenId4VPConfig(
+                    jarmConfiguration = JarmConfiguration.NotSupported,
+                    vpConfiguration = VPConfiguration(
+                        presentationDefinitionUriSupported = false,
+                        emptyMap(),
+                    ),
+                    supportedClientIdSchemes = listOf(
+                        SupportedClientIdScheme.RedirectUri,
+                    ),
+                ),
+            )
+
+            val clientId = URI.create("http://localhost:8080")
+            val request = UnvalidatedRequestObject(
+                clientId = clientId.toString(),
+                clientIdScheme = "redirect_uri",
+            ).plain()
+
+            val client = clientAuthenticator.authenticateClient(request)
+            assertEquals(AuthenticatedClient.RedirectUri(clientId), client)
+        }
+
+    @Test
+    fun `when scheme is redirect_uri signed request fail`() = runTest {
+        val clientAuthenticator = ClientAuthenticator(
+            SiopOpenId4VPConfig(
+                jarmConfiguration = JarmConfiguration.NotSupported,
+                vpConfiguration = VPConfiguration(
+                    presentationDefinitionUriSupported = false,
+                    emptyMap(),
+                ),
+                supportedClientIdSchemes = listOf(
+                    SupportedClientIdScheme.RedirectUri,
+                ),
+            ),
+        )
+
+        val clientId = URI.create("http://localhost:8080")
+        val (alg, key) = randomKey()
+        val request = UnvalidatedRequestObject(
+            clientId = clientId.toString(),
+            clientIdScheme = "redirect_uri",
+        ).signed(alg, key)
+
+        val error = assertFailsWithError<RequestValidationError.InvalidClientIdScheme> {
+            clientAuthenticator.authenticateClient(request)
+        }
+        assertEquals("RedirectUri cannot be used in signed request", error.value)
+    }
+
+    @Test
+    fun `when scheme is did signed request passes`() = runTest {
+        val clientId = DID.parse("did:example:123").getOrThrow()
+        val keyUrl = AbsoluteDIDUrl.parse("$clientId#01").getOrThrow()
+        val (alg, key) = randomKey()
+
+        val clientAuthenticator = ClientAuthenticator(
+            SiopOpenId4VPConfig(
+                jarmConfiguration = JarmConfiguration.NotSupported,
+                vpConfiguration = VPConfiguration(
+                    presentationDefinitionUriSupported = false,
+                    emptyMap(),
+                ),
+                supportedClientIdSchemes = listOf(
+                    SupportedClientIdScheme.DID { url ->
+                        assertEquals(keyUrl.uri, url)
+                        key.toPublicKey()
+                    },
+                ),
+            ),
+        )
+
+        val request = UnvalidatedRequestObject(
+            clientId = clientId.toString(),
+            clientIdScheme = "did",
+        ).signed(alg, key) { keyID(keyUrl.toString()) }
+
+        val client = clientAuthenticator.authenticateClient(request)
+        assertEquals(AuthenticatedClient.DIDClient(clientId, key.toPublicKey()), client)
+    }
+}
+
+private fun randomKey(): Pair<JWSAlgorithm, ECKey> =
+    JWSAlgorithm.ES256 to ECKeyGenerator(Curve.P_256).keyUse(KeyUse.SIGNATURE).generate()
+
+private inline fun <reified E : AuthorizationRequestError> assertFailsWithError(block: () -> Unit): E {
+    val exception = assertThrows<AuthorizationRequestException>(block)
+    return assertIs<E>(exception.error)
+}
+
+private fun UnvalidatedRequestObject.plain(): FetchedRequest.Plain =
+    FetchedRequest.Plain(this)
+
+private fun UnvalidatedRequestObject.signed(
+    alg: JWSAlgorithm,
+    key: JWK,
+    headerCustomization: (JWSHeader.Builder).() -> Unit = {},
+): FetchedRequest.JwtSecured = FetchedRequest.JwtSecured(
+    clientId = checkNotNull(clientId),
+    jwt = run {
+        val header = with(JWSHeader.Builder(alg)) {
+            type(JOSEObjectType("oauth-authz-req+jwt"))
+            headerCustomization()
+            build()
+        }
+        val claimsSet = toJWTClaimSet()
+        SignedJWT(header, claimsSet).apply {
+            val signer = DefaultJWSSignerFactory().createJWSSigner(key, alg)
+            sign(signer)
+        }
+    },
+)
+
+private fun UnvalidatedRequestObject.toJWTClaimSet(): JWTClaimsSet {
+    val json = Json.encodeToString(this)
+    return JWTClaimsSet.parse(json)
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticatorTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticatorTest.kt
@@ -52,6 +52,7 @@ class ClientAuthenticatorCommonTest {
         supportedClientIdSchemes = listOf(
             SupportedClientIdScheme.RedirectUri,
         ),
+        clock = Clock.systemDefaultZone(),
     )
     private val clientAuthenticator = ClientAuthenticator(cfg)
 
@@ -98,6 +99,7 @@ class ClientAuthenticatorWhenUsingRedirectUriTest {
         supportedClientIdSchemes = listOf(
             SupportedClientIdScheme.RedirectUri,
         ),
+        clock = Clock.systemDefaultZone(),
     )
     private val clientAuthenticator = ClientAuthenticator(cfg)
 
@@ -143,6 +145,7 @@ class ClientAuthenticatorWhenUsingDIDTest {
                 algAndKey.second.toPublicKey()
             },
         ),
+        clock = Clock.systemDefaultZone(),
     )
     private val clientAuthenticator = ClientAuthenticator(cfg)
     private val requestObject = UnvalidatedRequestObject(
@@ -284,6 +287,7 @@ class ClientAuthenticatorWhenUsingVerifierAttestationTest {
         supportedClientIdSchemes = listOf(
             SupportedClientIdScheme.VerifierAttestation(AttestationIssuer.verifier),
         ),
+        clock = Clock.systemDefaultZone(),
     )
     private val clientAuthenticator = ClientAuthenticator(cfg)
     private val requestObject = UnvalidatedRequestObject(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticatorTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticatorTest.kt
@@ -286,7 +286,7 @@ class ClientAuthenticatorWhenUsingVerifierAttestationTest {
         val (alg, key) = algAndKey
 
         val verifierAttestation = AttestationIssuer.attestation(
-            clock = Clock.systemDefaultZone(),
+            clock = cfg.clock,
             clientId = clientId,
             clientPubKey = key.toPublicJWK(),
         )

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponseBuilderTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponseBuilderTest.kt
@@ -38,6 +38,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import org.junit.jupiter.api.assertDoesNotThrow
+import java.time.Clock
 import kotlin.test.Test
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
@@ -53,6 +54,7 @@ class AuthorizationResponseBuilderTest {
                 supportedAlgorithms = listOf(JWEAlgorithm.ECDH_ES),
                 supportedMethods = listOf(EncryptionMethod.A256GCM),
             ),
+            clock = Clock.systemDefaultZone(),
         )
 
         val clientMetaDataValidator = ManagedClientMetaValidator(DefaultHttpClientFactory)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponseDispatcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponseDispatcherTest.kt
@@ -37,6 +37,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.jupiter.api.assertDoesNotThrow
 import java.io.InputStream
+import java.time.Clock
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -47,7 +48,7 @@ class AuthorizationResponseDispatcherTest {
 
     private val walletConfig = SiopOpenId4VPConfig(
         supportedClientIdSchemes = listOf(SupportedClientIdScheme.X509SanDns { _ -> true }),
-
+        clock = Clock.systemDefaultZone(),
     )
 
     private val clientMetadataStr =

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
@@ -56,6 +56,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.net.URI
+import java.time.Clock
 import java.util.*
 import kotlin.test.*
 
@@ -117,6 +118,7 @@ class DefaultDispatcherTest {
                 supportedEncryptionAlgorithms = listOf(Verifier.jarmEncryptionKeyPair.algorithm as JWEAlgorithm),
                 supportedEncryptionMethods = listOf(EncryptionMethod.A256GCM),
             ),
+            clock = Clock.systemDefaultZone(),
         )
 
         /**


### PR DESCRIPTION
This PR adds support for two additional `client_id_scheme`(s) 
- `did`
- `verifier_attestation`

### DID

To be used wallet needs to add to its configuration an instance of `SupportedClientIdScheme.DID`.
Effectually, to do so, it has to provide a way to lookup verifier's public key using a  DID URL via DID resolution.
The later is out of scope of the library

### Verifier Attestation
 
To be used wallet needs to add to its configuration an instance of `SupportedClientIdScheme.VerifierAttestation`.
To do so, wallet has to provide a `JWSVerifier` capable of verifying the signature of verifier attestation JWT from trusted issuers.

Closes #244 
Closes #126 