### PR TITLE
Align WalletResponse with the latest Verifier Endpoint version.

### DIFF
--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
@@ -34,6 +34,7 @@ import io.ktor.serialization.kotlinx.json.*
 import kotlinx.coroutines.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
@@ -86,7 +87,7 @@ fun main(): Unit = runBlocking {
 @Serializable
 data class WalletResponse(
     @SerialName("id_token") val idToken: String? = null,
-    @SerialName("vp_token") val vpToken: String? = null,
+    @SerialName("vp_token") val vpToken: JsonArray? = null,
     @SerialName("presentation_submission") val presentationSubmission: PresentationSubmission? = null,
     @SerialName("error") val error: String? = null,
 )


### PR DESCRIPTION
Depends on https://github.com/eu-digital-identity-wallet/eudi-srv-web-verifier-endpoint-23220-4-kt/pull/194 being merged first.