### PR TITLE
Check wallet/verifier metadata for format compatibility

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -170,6 +170,14 @@ data class VpFormats(
             VpFormats(sdJwt, msoMdoc)
         }
 
+        fun intersect(thiz: VpFormats, that: VpFormats): VpFormats? {
+            val scg = thiz.sdJwtVc?.intersect(that.sdJwtVc)
+            val mcg = thiz.msoMdoc?.intersect(that.msoMdoc)
+            return if (scg != null || mcg != null) {
+                VpFormats(scg, mcg)
+            } else null
+        }
+
         private fun ensureUniquePerFormat(formats: Iterable<VpFormat>) {
             formats
                 .groupBy { it.formatName() }
@@ -331,6 +339,16 @@ sealed interface VpFormat : java.io.Serializable {
             require(sdJwtAlgorithms.isNotEmpty()) { "SD-JWT algorithms cannot be empty" }
         }
 
+        fun intersect(that: SdJwtVc?): SdJwtVc? {
+            if (that == null) return null
+
+            val kbJwtAlgs = kbJwtAlgorithms.intersect(that.kbJwtAlgorithms.toSet())
+            val sdJwtAlgs = sdJwtAlgorithms.intersect(that.sdJwtAlgorithms.toSet())
+            return if (sdJwtAlgs.isNotEmpty() && kbJwtAlgs.isNotEmpty())
+                SdJwtVc(sdJwtAlgs.toList(), kbJwtAlgs.toList())
+            else null
+        }
+
         companion object {
             val ES256 = SdJwtVc(listOf(JWSAlgorithm.ES256), listOf(JWSAlgorithm.ES256))
         }
@@ -339,6 +357,15 @@ sealed interface VpFormat : java.io.Serializable {
     data class MsoMdoc(val algorithms: List<JWSAlgorithm>) : VpFormat {
         init {
             require(algorithms.isNotEmpty()) { "Mso-doc algorithms cannot be empty" }
+        }
+
+        fun intersect(that: MsoMdoc?): MsoMdoc? {
+            if (that == null) return null
+
+            val algs = algorithms.intersect(that.algorithms.toSet())
+            return if (algs.isNotEmpty())
+                MsoMdoc(algs.toList())
+            else null
         }
 
         companion object {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/ClientMetaDataValidator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/ClientMetaDataValidator.kt
@@ -59,7 +59,7 @@ internal class ClientMetaDataValidator(private val httpClient: HttpClient) {
 
     private fun vpFormats(unvalidated: UnvalidatedClientMetaData): VpFormats =
         try {
-            VpFormats(unvalidated.vpFormats?.formats().orEmpty())
+            unvalidated.vpFormats.toDomain()
         } catch (e: IllegalArgumentException) {
             throw RequestValidationError.InvalidClientMetaData("Invalid vp_format").asException()
         }
@@ -108,7 +108,7 @@ private fun authSgnRespAlg(unvalidated: UnvalidatedClientMetaData, responseMode:
         ?: throw RequestValidationError.InvalidClientMetaData("Invalid signing algorithm $unvalidatedAlg").asException()
 }
 
-private fun String.signingAlg(): JWSAlgorithm? =
+internal fun String.signingAlg(): JWSAlgorithm? =
     JWSAlgorithm.parse(this).takeIf { JWSAlgorithm.Family.SIGNATURE.contains(it) }
 
 private fun String.encAlg(): JWEAlgorithm? = JWEAlgorithm.parse(this)
@@ -172,20 +172,20 @@ private fun parseSubjectSyntaxType(value: String): SubjectSyntaxType? {
     }
 }
 
-private fun VpFormatsTO.formats(): List<VpFormat> {
-    fun VcSdJwtTO.format(): VpFormat.SdJwtVc {
-        fun List<String>?.algs() = this?.mapNotNull { it.signingAlg() }.orEmpty()
-        return VpFormat.SdJwtVc(
-            sdJwtAlgorithms = sdJwtAlgorithms.algs(),
-            kbJwtAlgorithms = kdJwtAlgorithms.algs(),
-        )
-    }
-
-    return buildList {
-        msoMdoc?.let { add(VpFormat.MsoMdoc) }
-        vcSdJwt?.let { sdJwtVc -> add(sdJwtVc.format()) }
-    }
-}
+// private fun VpFormatsTO.formats(): List<VpFormat> {
+//    fun VcSdJwtTO.format(): VpFormat.SdJwtVc {
+//        fun List<String>?.algs() = this?.mapNotNull { it.signingAlg() }.orEmpty()
+//        return VpFormat.SdJwtVc(
+//            sdJwtAlgorithms = sdJwtAlgorithms.algs(),
+//            kbJwtAlgorithms = kdJwtAlgorithms.algs(),
+//        )
+//    }
+//
+//    return buildList {
+//        msoMdoc?.let { add(VpFormat.MsoMdoc) }
+//        vcSdJwt?.let { sdJwtVc -> add(sdJwtVc.format()) }
+//    }
+// }
 
 private fun <T> bothOrNone(left: T, right: T): ((T) -> Boolean) -> Boolean = { test ->
     when (test(left) to test(right)) {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationRequestErrorCode.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationRequestErrorCode.kt
@@ -106,6 +106,8 @@ internal enum class AuthorizationRequestErrorCode(val code: String) {
                 -> PROCESSING_FAILURE
 
                 is InvalidTransactionData -> INVALID_TRANSACTION_DATA
+
+                ClientVpFormatsNotSupportedFromWallet -> VP_FORMATS_NOT_SUPPORTED
             }
         }
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/ConfigTests.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/ConfigTests.kt
@@ -25,7 +25,7 @@ class ConfigTests {
     @Test
     fun `vp_format with at most one instance per format is ok`() {
         assertDoesNotThrow {
-            VpFormats(VpFormat.MsoMdoc, VpFormat.SdJwtVc.ES256)
+            VpFormats(VpFormat.MsoMdoc.ES256, VpFormat.SdJwtVc.ES256)
         }
     }
 
@@ -33,18 +33,18 @@ class ConfigTests {
     fun `vp_format with multiple format instances for a given format is not allowed`() {
         assertThrows<IllegalArgumentException> {
             VpFormats(
-                VpFormat.MsoMdoc,
-                VpFormat.MsoMdoc,
+                VpFormat.MsoMdoc(listOf(JWSAlgorithm.ES384)),
+                VpFormat.MsoMdoc(listOf(JWSAlgorithm.ES384)),
             )
         }
 
         assertThrows<IllegalArgumentException> {
             VpFormats(
-                VpFormat.sdJwtVc(
+                VpFormat.SdJwtVc(
                     sdJwtAlgorithms = listOf(JWSAlgorithm.ES384),
                     kbJwtAlgorithms = listOf(JWSAlgorithm.ES256),
                 ),
-                VpFormat.sdJwtVc(
+                VpFormat.SdJwtVc(
                     sdJwtAlgorithms = listOf(JWSAlgorithm.RS256),
                     kbJwtAlgorithms = listOf(JWSAlgorithm.RS256),
                 ),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
@@ -524,7 +524,7 @@ object SslSettings {
 private fun walletConfig(vararg supportedClientIdScheme: SupportedClientIdScheme) =
     SiopOpenId4VPConfig(
         vpConfiguration = VPConfiguration(
-            vpFormats = VpFormats(VpFormat.MsoMdoc),
+            vpFormats = VpFormats(VpFormat.SdJwtVc.ES256, VpFormat.MsoMdoc.ES256),
             supportedTransactionDataTypes = listOf(
                 SupportedTransactionDataType(
                     TransactionDataType("eu.europa.ec.eudi.family-name-presentation"),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticatorTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticatorTest.kt
@@ -52,7 +52,7 @@ class ClientAuthenticatorTest {
                 SupportedClientIdScheme.RedirectUri,
             ),
             vpConfiguration = VPConfiguration(
-                vpFormats = VpFormats(VpFormat.MsoMdoc, VpFormat.SdJwtVc.ES256),
+                vpFormats = VpFormats(VpFormat.SdJwtVc.ES256, VpFormat.MsoMdoc.ES256),
             ),
             clock = Clock.systemDefaultZone(),
         )
@@ -88,7 +88,7 @@ class ClientAuthenticatorTest {
                 SupportedClientIdScheme.RedirectUri,
             ),
             vpConfiguration = VPConfiguration(
-                vpFormats = VpFormats(VpFormat.MsoMdoc, VpFormat.SdJwtVc.ES256),
+                vpFormats = VpFormats(VpFormat.SdJwtVc.ES256, VpFormat.MsoMdoc.ES256),
             ),
         )
         private val clientAuthenticator = ClientAuthenticator(cfg)
@@ -132,7 +132,7 @@ class ClientAuthenticatorTest {
                 },
             ),
             vpConfiguration = VPConfiguration(
-                vpFormats = VpFormats(VpFormat.MsoMdoc, VpFormat.SdJwtVc.ES256),
+                vpFormats = VpFormats(VpFormat.SdJwtVc.ES256, VpFormat.MsoMdoc.ES256),
             ),
         )
         private val clientAuthenticator = ClientAuthenticator(cfg)
@@ -237,7 +237,7 @@ class ClientAuthenticatorTest {
                 SupportedClientIdScheme.VerifierAttestation(AttestationIssuer.verifier),
             ),
             vpConfiguration = VPConfiguration(
-                vpFormats = VpFormats(VpFormat.MsoMdoc, VpFormat.SdJwtVc.ES256),
+                vpFormats = VpFormats(VpFormat.SdJwtVc.ES256, VpFormat.MsoMdoc.ES256),
             ),
             clock = Clock.systemDefaultZone(),
         )

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
@@ -34,11 +34,8 @@ class WalletMetaDataTest {
                 presentationDefinitionUriSupported = false,
                 knownPresentationDefinitionsPerScope = emptyMap(),
                 vpFormats = VpFormats(
-                    VpFormat.MsoMdoc,
-                    VpFormat.sdJwtVc(
-                        sdJwtAlgorithms = listOf(JWSAlgorithm.ES256),
-                        kbJwtAlgorithms = listOf(JWSAlgorithm.ES256),
-                    ),
+                    VpFormat.SdJwtVc.ES256,
+                    VpFormat.MsoMdoc.ES256,
                 ),
             ),
             jarmConfiguration = JarmConfiguration.Encryption(
@@ -57,8 +54,8 @@ class WalletMetaDataTest {
                 presentationDefinitionUriSupported = false,
                 knownPresentationDefinitionsPerScope = emptyMap(),
                 vpFormats = VpFormats(
-                    VpFormat.MsoMdoc,
                     VpFormat.SdJwtVc.ES256,
+                    VpFormat.MsoMdoc.ES256,
                 ),
             ),
             jarmConfiguration = JarmConfiguration.NotSupported,
@@ -165,13 +162,12 @@ private fun assertExpectedVpFormats(
         walletMetaData["vp_formats_supported"],
         "Missing vp_formats_supported",
     )
-    assertEquals(vpFormats.size, vpFormats.size)
-    if (VpFormat.MsoMdoc in expectedVpFormats) {
+    if (expectedVpFormats.msoMdoc != null) {
         val msoMdoc = assertNotNull(vpFormats["mso_mdoc"])
         assertIs<JsonObject>(msoMdoc)
-        assertTrue { msoMdoc.isEmpty() }
+        assertTrue { msoMdoc.isNotEmpty() }
     }
-    val sdJwtVcSupport = expectedVpFormats.values.filterIsInstance<VpFormat.SdJwtVc>().firstOrNull()
+    val sdJwtVcSupport = expectedVpFormats.sdJwtVc
     if (sdJwtVcSupport != null) {
         val sdJwtVc = assertNotNull(vpFormats["vc+sd-jwt"])
         assertIs<JsonObject>(sdJwtVc)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponseBuilderTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponseBuilderTest.kt
@@ -28,6 +28,7 @@ import com.nimbusds.oauth2.sdk.id.State
 import eu.europa.ec.eudi.openid4vp.*
 import eu.europa.ec.eudi.openid4vp.internal.request.ManagedClientMetaValidator
 import eu.europa.ec.eudi.openid4vp.internal.request.UnvalidatedClientMetaData
+import eu.europa.ec.eudi.openid4vp.internal.request.VpFormatsTO
 import eu.europa.ec.eudi.openid4vp.internal.request.asURL
 import eu.europa.ec.eudi.openid4vp.internal.request.jarmRequirement
 import eu.europa.ec.eudi.prex.Id
@@ -55,7 +56,7 @@ class AuthorizationResponseBuilderTest {
                 supportedMethods = listOf(EncryptionMethod.A256GCM),
             ),
             vpConfiguration = VPConfiguration(
-                vpFormats = VpFormats(VpFormat.MsoMdoc, VpFormat.SdJwtVc.ES256),
+                vpFormats = VpFormats(VpFormat.SdJwtVc.ES256, VpFormat.MsoMdoc.ES256),
             ),
             clock = Clock.systemDefaultZone(),
         )
@@ -77,12 +78,18 @@ class AuthorizationResponseBuilderTest {
                 "did:example",
                 "did:key",
             ),
+            vpFormats = VpFormatsTO.make(
+                VpFormats(msoMdoc = VpFormat.MsoMdoc.ES256),
+            ),
         )
 
         val metaDataRequestingEncryptedResponse = UnvalidatedClientMetaData(
             jwks = JWKSet(jarmEncryptionKeyPair).toJsonObject(true),
             authorizationEncryptedResponseAlg = jarmEncryptionKeyPair.algorithm.name,
             authorizationEncryptedResponseEnc = EncryptionMethod.A256GCM.name,
+            vpFormats = VpFormatsTO.make(
+                VpFormats(msoMdoc = VpFormat.MsoMdoc.ES256),
+            ),
         )
 
         private fun JWKSet.toJsonObject(publicKeysOnly: Boolean = true): JsonObject =
@@ -154,7 +161,7 @@ class AuthorizationResponseBuilderTest {
                         ),
                     ),
                     jarmRequirement = Wallet.config.jarmRequirement(verifierMetaData),
-                    vpFormats = VpFormats(VpFormat.MsoMdoc),
+                    vpFormats = VpFormats(msoMdoc = VpFormat.MsoMdoc.ES256),
                     client = Client.Preregistered("https%3A%2F%2Fclient.example.org%2Fcb", "Verifier"),
                     nonce = "0S6_WzA2Mj",
                     responseMode = responseMode,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponseDispatcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponseDispatcherTest.kt
@@ -50,14 +50,14 @@ class AuthorizationResponseDispatcherTest {
     private val walletConfig = SiopOpenId4VPConfig(
         supportedClientIdSchemes = listOf(SupportedClientIdScheme.X509SanDns.NoValidation),
         vpConfiguration = VPConfiguration(
-            vpFormats = VpFormats(VpFormat.MsoMdoc, VpFormat.SdJwtVc.ES256),
+            vpFormats = VpFormats(VpFormat.SdJwtVc.ES256, VpFormat.MsoMdoc.ES256),
         ),
         clock = Clock.systemDefaultZone(),
     )
 
     private val clientMetadataStr =
         """
-            { "jwks": { "keys": [ { "kty": "RSA", "e": "AQAB", "use": "sig", "kid": "a4e1bbe6-26e8-480b-a364-f43497894453", "iat": 1683559586, "n": "xHI9zoXS-fOAFXDhDmPMmT_UrU1MPimy0xfP-sL0Iu4CQJmGkALiCNzJh9v343fqFT2hfrbigMnafB2wtcXZeEDy6Mwu9QcJh1qLnklW5OOdYsLJLTyiNwMbLQXdVxXiGby66wbzpUymrQmT1v80ywuYd8Y0IQVyteR2jvRDNxy88bd2eosfkUdQhNKUsUmpODSxrEU2SJCClO4467fVdPng7lyzF2duStFeA2vUkZubor3EcrJ72JbZVI51YDAqHQyqKZIDGddOOvyGUTyHz9749bsoesqXHOugVXhc2elKvegwBik3eOLgfYKJwisFcrBl62k90RaMZpXCxNO4Ew" } ] }, "id_token_encrypted_response_alg": "RS256", "id_token_encrypted_response_enc": "A128CBC-HS256", "subject_syntax_types_supported": [ "urn:ietf:params:oauth:jwk-thumbprint", "did:example", "did:key" ], "id_token_signed_response_alg": "RS256" }
+            { "jwks": { "keys": [ { "kty": "RSA", "e": "AQAB", "use": "sig", "kid": "a4e1bbe6-26e8-480b-a364-f43497894453", "iat": 1683559586, "n": "xHI9zoXS-fOAFXDhDmPMmT_UrU1MPimy0xfP-sL0Iu4CQJmGkALiCNzJh9v343fqFT2hfrbigMnafB2wtcXZeEDy6Mwu9QcJh1qLnklW5OOdYsLJLTyiNwMbLQXdVxXiGby66wbzpUymrQmT1v80ywuYd8Y0IQVyteR2jvRDNxy88bd2eosfkUdQhNKUsUmpODSxrEU2SJCClO4467fVdPng7lyzF2duStFeA2vUkZubor3EcrJ72JbZVI51YDAqHQyqKZIDGddOOvyGUTyHz9749bsoesqXHOugVXhc2elKvegwBik3eOLgfYKJwisFcrBl62k90RaMZpXCxNO4Ew" } ] }, "id_token_encrypted_response_alg": "RS256", "id_token_encrypted_response_enc": "A128CBC-HS256", "subject_syntax_types_supported": [ "urn:ietf:params:oauth:jwk-thumbprint", "did:example", "did:key" ], "id_token_signed_response_alg": "RS256", "vp_formats": { "mso_mdoc": {"alg":  ["ES256"]} } }
         """.trimIndent()
 
     private val clientMetaData = json.decodeFromString<UnvalidatedClientMetaData>(clientMetadataStr)
@@ -162,7 +162,7 @@ class AuthorizationResponseDispatcherTest {
             val openId4VPAuthRequestObject =
                 ResolvedRequestObject.OpenId4VPAuthorization(
                     jarmRequirement = walletConfig.jarmRequirement(validated),
-                    vpFormats = VpFormats(VpFormat.MsoMdoc),
+                    vpFormats = VpFormats(msoMdoc = VpFormat.MsoMdoc.ES256),
                     client = Client.Preregistered("https%3A%2F%2Fclient.example.org%2Fcb", "Verifier"),
                     nonce = "0S6_WzA2Mj",
                     responseMode = responseMode,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
@@ -36,6 +36,7 @@ import eu.europa.ec.eudi.openid4vp.dcql.*
 import eu.europa.ec.eudi.openid4vp.dcql.ClaimPathElement.Claim
 import eu.europa.ec.eudi.openid4vp.internal.request.ManagedClientMetaValidator
 import eu.europa.ec.eudi.openid4vp.internal.request.UnvalidatedClientMetaData
+import eu.europa.ec.eudi.openid4vp.internal.request.VpFormatsTO
 import eu.europa.ec.eudi.openid4vp.internal.request.asURL
 import eu.europa.ec.eudi.openid4vp.internal.request.jarmRequirement
 import eu.europa.ec.eudi.openid4vp.internal.response.DefaultDispatcherTest.Verifier.assertIsJwtEncryptedWithVerifiersPubKey
@@ -82,6 +83,9 @@ class DefaultDispatcherTest {
             jwks = JWKSet(jarmEncryptionKeyPair).toJsonObject(true),
             authorizationEncryptedResponseAlg = jarmEncryptionKeyPair.algorithm.name,
             authorizationEncryptedResponseEnc = EncryptionMethod.A256GCM.name,
+            vpFormats = VpFormatsTO.make(
+                VpFormats(msoMdoc = VpFormat.MsoMdoc.ES256),
+            ),
         )
 
         val metaDataRequestingSignedAndEncryptedResponse = metaDataRequestingEncryptedResponse.copy(
@@ -121,7 +125,7 @@ class DefaultDispatcherTest {
                 supportedEncryptionMethods = listOf(EncryptionMethod.A256GCM),
             ),
             vpConfiguration = VPConfiguration(
-                vpFormats = VpFormats(VpFormat.MsoMdoc, VpFormat.SdJwtVc.ES256),
+                vpFormats = VpFormats(VpFormat.SdJwtVc.ES256, VpFormat.MsoMdoc.ES256),
             ),
             clock = Clock.systemDefaultZone(),
         )
@@ -343,6 +347,9 @@ class DefaultDispatcherTest {
             suspend fun test(redirectUri: URI? = null) {
                 val verifierMetaData = UnvalidatedClientMetaData(
                     authorizationSignedResponseAlg = JWSAlgorithm.RS256.name,
+                    vpFormats = VpFormatsTO.make(
+                        VpFormats(msoMdoc = VpFormat.MsoMdoc.ES256),
+                    ),
                 )
                 val responseMode = ResponseMode.DirectPostJwt("https://respond.here".asURL().getOrThrow())
 
@@ -385,6 +392,9 @@ class DefaultDispatcherTest {
             suspend fun test(vpContent: VpContent, redirectUri: URI? = null) {
                 val verifierMetaData = UnvalidatedClientMetaData(
                     authorizationSignedResponseAlg = JWSAlgorithm.RS256.name,
+                    vpFormats = VpFormatsTO.make(
+                        VpFormats(msoMdoc = VpFormat.MsoMdoc.ES256),
+                    ),
                 )
                 val responseMode = ResponseMode.DirectPostJwt("https://respond.here".asURL().getOrThrow())
 
@@ -450,6 +460,9 @@ class DefaultDispatcherTest {
 
             val verifierMetaData = UnvalidatedClientMetaData(
                 authorizationSignedResponseAlg = JWSAlgorithm.RS256.name,
+                vpFormats = VpFormatsTO.make(
+                    VpFormats(msoMdoc = VpFormat.MsoMdoc.ES256),
+                ),
             )
             val responseMode = ResponseMode.DirectPostJwt("https://respond.here".asURL().getOrThrow())
 
@@ -524,7 +537,7 @@ class DefaultDispatcherTest {
                     ),
                 ),
                 jarmRequirement = Wallet.config.jarmRequirement(clientMetadataValidated),
-                vpFormats = VpFormats(VpFormat.MsoMdoc),
+                vpFormats = VpFormats(msoMdoc = VpFormat.MsoMdoc.ES256),
                 client = Verifier.CLIENT,
                 nonce = "0S6_WzA2Mj",
                 responseMode = responseMode,
@@ -549,7 +562,7 @@ class DefaultDispatcherTest {
                     ),
                 ),
                 jarmRequirement = Wallet.config.jarmRequirement(clientMetadataValidated),
-                vpFormats = VpFormats(VpFormat.MsoMdoc),
+                vpFormats = VpFormats(msoMdoc = VpFormat.MsoMdoc.ES256),
                 client = Verifier.CLIENT,
                 nonce = "0S6_WzA2Mj",
                 responseMode = responseMode,
@@ -571,7 +584,7 @@ class DefaultDispatcherTest {
                 state = genState(),
                 nonce = "0S6_WzA2Mj",
                 jarmRequirement = Wallet.config.jarmRequirement(clientMetadataValidated),
-                vpFormats = VpFormats(VpFormat.MsoMdoc),
+                vpFormats = VpFormats(msoMdoc = VpFormat.MsoMdoc.ES256),
                 idTokenType = listOf(IdTokenType.SubjectSigned),
                 subjectSyntaxTypesSupported = listOf(SubjectSyntaxType.DecentralizedIdentifier("")),
                 scope = Scope.OpenId,

--- a/src/test/resources/example/sd-jwt-vc-pid-presentation-definition.json
+++ b/src/test/resources/example/sd-jwt-vc-pid-presentation-definition.json
@@ -10,9 +10,7 @@
           "sd-jwt_alg_values": [
             "ES256",
             "ES384",
-            "RS256",
-            "RS384",
-            "RS512"
+            "ES512"
           ],
           "kb-jwt_alg_values": [
             "ES256",


### PR DESCRIPTION
- When client_metadata included in authorization request vp_formats are expected to be present
- When vp_formats attribute is included in client metadata, deduct the common ground between wallet and requester regarding the formats they both can support (along with format specific attributes)

Closes #319 