### PR TITLE
Implement error dispatching

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
@@ -496,16 +496,24 @@ sealed interface Resolution {
      * Represents the failure of validating or resolving an authorization request
      * due to [error]
      */
-    data class Invalid(val error: AuthorizationRequestError, val di: ErrorDispatchDetails?) : Resolution
+    data class Invalid(
+        val error: AuthorizationRequestError,
+        val dispatchDetails: ErrorDispatchDetails?,
+    ) : Resolution
 }
 
+/**
+ * Information required for an [AuthorizationRequestError] to be dispatchable.
+ */
 data class ErrorDispatchDetails(
     val responseMode: ResponseMode,
     val nonce: String?,
     val state: String?,
     val clientId: VerifierId?,
     val jarmRequirement: JarmRequirement?,
-) : Serializable
+) : Serializable {
+    companion object
+}
 
 /**
  * An interface that describes a service

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
@@ -494,8 +494,17 @@ sealed interface Resolution {
      * Represents the failure of validating or resolving an authorization request
      * due to [error]
      */
-    data class Invalid(val error: AuthorizationRequestError) : Resolution
+    data class Invalid(val error: AuthorizationRequestError, val di: ErrorDispatchDetails?) : Resolution
 }
+
+data class ErrorDispatchDetails(
+    val responseMode: ResponseMode,
+    val nonce: String?,
+    val state: String?,
+    val clientId: VerifierId?,
+    val jarmRequirement: JarmRequirement?,
+): Serializable
+
 
 /**
  * An interface that describes a service

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
@@ -499,7 +499,12 @@ sealed interface Resolution {
     data class Invalid(
         val error: AuthorizationRequestError,
         val dispatchDetails: ErrorDispatchDetails?,
-    ) : Resolution
+    ) : Resolution {
+
+        companion object {
+            fun nonDispatchable(error: AuthorizationRequestError): Invalid = Invalid(error, null)
+        }
+    }
 }
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
@@ -16,6 +16,8 @@
 package eu.europa.ec.eudi.openid4vp
 
 import eu.europa.ec.eudi.openid4vp.Client.*
+import eu.europa.ec.eudi.openid4vp.ResolvedRequestObject.OpenId4VPAuthorization
+import eu.europa.ec.eudi.openid4vp.ResolvedRequestObject.SiopOpenId4VPAuthentication
 import eu.europa.ec.eudi.openid4vp.dcql.DCQL
 import eu.europa.ec.eudi.openid4vp.internal.*
 import eu.europa.ec.eudi.openid4vp.internal.request.RequestUriMethod
@@ -503,8 +505,7 @@ data class ErrorDispatchDetails(
     val state: String?,
     val clientId: VerifierId?,
     val jarmRequirement: JarmRequirement?,
-): Serializable
-
+) : Serializable
 
 /**
  * An interface that describes a service

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -191,6 +191,7 @@ data class VpFormats(
         private enum class FormatName {
             MSO_MDOC, SD_JWT_VC
         }
+
         private fun VpFormat.formatName() = when (this) {
             is VpFormat.MsoMdoc -> FormatName.MSO_MDOC
             is VpFormat.SdJwtVc -> FormatName.SD_JWT_VC
@@ -463,6 +464,22 @@ data class JarConfiguration(
 }
 
 /**
+ * Wallets policy regarding error dispatching.
+ */
+enum class ErrorDispatchPolicy : java.io.Serializable {
+
+    /**
+     * Allow dispatching of errors to all clients, regardless of authentication status.
+     */
+    AllClients,
+
+    /**
+     * Allow dispatching of errors only to authenticated clients.
+     */
+    OnlyAuthenticatedClients,
+}
+
+/**
  * Wallet configuration options for SIOP & OpenId4VP protocols.
  *
  * At minimum, a wallet configuration should define at least a [supportedClientIdSchemes]
@@ -476,6 +493,7 @@ data class JarConfiguration(
  * @param clock the system Clock. If not provided system's default clock will be used.
  * @param jarClockSkew max acceptable skew between wallet and verifier
  * @param supportedClientIdSchemes the client id schemes that are supported/trusted by the wallet
+ * @param errorDispatchPolicy wallet's policy regarding error dispatching. Defaults to [ErrorDispatchPolicy.OnlyAuthenticatedClients].
  */
 data class SiopOpenId4VPConfig(
     val issuer: Issuer? = SelfIssued,
@@ -485,6 +503,7 @@ data class SiopOpenId4VPConfig(
     val clock: Clock = Clock.systemDefaultZone(),
     val jarClockSkew: Duration = Duration.ofSeconds(15L),
     val supportedClientIdSchemes: List<SupportedClientIdScheme>,
+    val errorDispatchPolicy: ErrorDispatchPolicy = ErrorDispatchPolicy.OnlyAuthenticatedClients,
 ) {
     init {
         require(supportedClientIdSchemes.isNotEmpty()) { "At least a supported client id scheme must be provided" }
@@ -497,6 +516,7 @@ data class SiopOpenId4VPConfig(
         vpConfiguration: VPConfiguration,
         clock: Clock = Clock.systemDefaultZone(),
         jarClockSkew: Duration = Duration.ofSeconds(15L),
+        errorDispatchPolicy: ErrorDispatchPolicy = ErrorDispatchPolicy.OnlyAuthenticatedClients,
         vararg supportedClientIdSchemes: SupportedClientIdScheme,
     ) : this(
         issuer,
@@ -506,6 +526,7 @@ data class SiopOpenId4VPConfig(
         clock,
         jarClockSkew,
         supportedClientIdSchemes.toList(),
+        errorDispatchPolicy,
     )
 
     companion object {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ErrorDispatcher.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ErrorDispatcher.kt
@@ -1,0 +1,28 @@
+package eu.europa.ec.eudi.openid4vp
+
+interface ErrorDispatcher {
+    suspend fun dispatchError(
+        error: AuthorizationRequestError,
+        di: ErrorDispatchDetails,
+        encryptionParameters: EncryptionParameters?,
+    ): DispatchOutcome = when (di.responseMode) {
+        is ResponseMode.DirectPost -> post(error, di, encryptionParameters)
+        is ResponseMode.DirectPostJwt -> post(error, di, encryptionParameters)
+        is ResponseMode.Query -> encodeRedirectURI(error, di, encryptionParameters)
+        is ResponseMode.QueryJwt -> encodeRedirectURI(error, di, encryptionParameters)
+        is ResponseMode.Fragment -> encodeRedirectURI(error, di, encryptionParameters)
+        is ResponseMode.FragmentJwt -> encodeRedirectURI(error, di, encryptionParameters)
+    }
+
+    suspend fun post(
+        error: AuthorizationRequestError,
+        di: ErrorDispatchDetails,
+        encryptionParameters: EncryptionParameters?,
+    ): DispatchOutcome.VerifierResponse
+
+    suspend fun encodeRedirectURI(
+        error: AuthorizationRequestError,
+        di: ErrorDispatchDetails,
+        encryptionParameters: EncryptionParameters?,
+    ): DispatchOutcome.RedirectURI
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ErrorDispatcher.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ErrorDispatcher.kt
@@ -23,15 +23,15 @@ interface ErrorDispatcher {
 
     suspend fun dispatchError(
         error: AuthorizationRequestError,
-        di: ErrorDispatchDetails,
+        errorDispatchDetails: ErrorDispatchDetails,
         encryptionParameters: EncryptionParameters?,
-    ): DispatchOutcome = when (di.responseMode) {
-        is ResponseMode.DirectPost -> post(error, di, encryptionParameters)
-        is ResponseMode.DirectPostJwt -> post(error, di, encryptionParameters)
-        is ResponseMode.Query -> encodeRedirectURI(error, di, encryptionParameters)
-        is ResponseMode.QueryJwt -> encodeRedirectURI(error, di, encryptionParameters)
-        is ResponseMode.Fragment -> encodeRedirectURI(error, di, encryptionParameters)
-        is ResponseMode.FragmentJwt -> encodeRedirectURI(error, di, encryptionParameters)
+    ): DispatchOutcome = when (errorDispatchDetails.responseMode) {
+        is ResponseMode.DirectPost -> post(error, errorDispatchDetails, encryptionParameters)
+        is ResponseMode.DirectPostJwt -> post(error, errorDispatchDetails, encryptionParameters)
+        is ResponseMode.Query -> encodeRedirectURI(error, errorDispatchDetails, encryptionParameters)
+        is ResponseMode.QueryJwt -> encodeRedirectURI(error, errorDispatchDetails, encryptionParameters)
+        is ResponseMode.Fragment -> encodeRedirectURI(error, errorDispatchDetails, encryptionParameters)
+        is ResponseMode.FragmentJwt -> encodeRedirectURI(error, errorDispatchDetails, encryptionParameters)
     }
 
     /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ErrorDispatcher.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ErrorDispatcher.kt
@@ -1,6 +1,26 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package eu.europa.ec.eudi.openid4vp
 
+/**
+ * This interface assembles an appropriate authorization error response given an [error][AuthorizationRequestError]
+ * that occurred during the authorization request resolution and then dispatches it to the verifier
+ */
 interface ErrorDispatcher {
+
     suspend fun dispatchError(
         error: AuthorizationRequestError,
         di: ErrorDispatchDetails,
@@ -14,15 +34,41 @@ interface ErrorDispatcher {
         is ResponseMode.FragmentJwt -> encodeRedirectURI(error, di, encryptionParameters)
     }
 
+    /**
+     * Method forms a suitable authorization response, based on the [error] and the provided [errorDispatchDetails], then
+     * post it to the Verifier's end-point and returns his response.
+     *
+     * This method is applicable when the [errorDispatchDetails] contains a [ErrorDispatchDetails.responseMode] which is
+     * either [ResponseMode.DirectPost] or [ResponseMode.DirectPostJwt].
+     *
+     * @param error The error to dispatch
+     * [ResponseMode.Query], [ResponseMode.QueryJwt], [ResponseMode.Fragment] or [ResponseMode.FragmentJwt]
+     * @param errorDispatchDetails Details on how to dispatch the error
+     * @return the verifier's response after receiving the authorization response.
+     */
     suspend fun post(
         error: AuthorizationRequestError,
-        di: ErrorDispatchDetails,
+        errorDispatchDetails: ErrorDispatchDetails,
         encryptionParameters: EncryptionParameters?,
     ): DispatchOutcome.VerifierResponse
 
+    /**
+     * Method forms a suitable authorization response, based on the [error] and the provided [errorDispatchDetails], and then
+     * encodes this response to a URI.
+     * To this URI, the wallet (caller) must redirect its authorization response
+     *
+     * This method is applicable when [errorDispatchDetails] contains a [ErrorDispatchDetails.responseMode] which is one of
+     * [ResponseMode.Query], [ResponseMode.QueryJwt], [ResponseMode.Fragment] or [ResponseMode.FragmentJwt]
+     *
+     * @param error The error to dispatch
+     * [ResponseMode.Query], [ResponseMode.QueryJwt], [ResponseMode.Fragment] or [ResponseMode.FragmentJwt]
+     * @param errorDispatchDetails Details on how to dispatch the error
+     * @return a URI pointing to the verifier to which the wallet(caller) must redirect its response. This URI carries
+     * the authorization response
+     */
     suspend fun encodeRedirectURI(
         error: AuthorizationRequestError,
-        di: ErrorDispatchDetails,
+        errorDispatchDetails: ErrorDispatchDetails,
         encryptionParameters: EncryptionParameters?,
     ): DispatchOutcome.RedirectURI
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ResponseDispatcher.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ResponseDispatcher.kt
@@ -52,8 +52,7 @@ sealed interface Consensus : Serializable {
          * In response to a [OpenId4VPAuthorization] where the
          * wallet has claims that fulfill Verifier's presentation definition
          * and holder has chosen the claims to include
-         * @param vpToken the vp_token to be included in the authorization response
-         * @param presentationSubmission the presentation submission to be included in the authorization response
+         * @param vpContent the VpContent to be included in the authorization response
          */
         data class VPTokenConsensus(
             val vpContent: VpContent,
@@ -63,8 +62,7 @@ sealed interface Consensus : Serializable {
          * In response to a [SiopOpenId4VPAuthentication]
          *
          * @param idToken The id_token produced by the wallet
-         * @param vpToken the vp_token to be included in the authorization response
-         * @param presentationSubmission the presentation submission to be included in the authorization response
+         * @param vpContent the VpContent to be included in the authorization response
          */
         data class IdAndVPTokenConsensus(
             val idToken: Jwt,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/SiopOpenId4Vp.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/SiopOpenId4Vp.kt
@@ -29,7 +29,7 @@ import eu.europa.ec.eudi.openid4vp.internal.response.DefaultDispatcher
  * @see AuthorizationRequestResolver
  * @see Dispatcher
  */
-interface SiopOpenId4Vp : AuthorizationRequestResolver, Dispatcher {
+interface SiopOpenId4Vp : AuthorizationRequestResolver, Dispatcher, ErrorDispatcher {
 
     companion object {
 
@@ -52,6 +52,7 @@ interface SiopOpenId4Vp : AuthorizationRequestResolver, Dispatcher {
             return object :
                 AuthorizationRequestResolver by requestResolver,
                 Dispatcher by dispatcher,
+                ErrorDispatcher by dispatcher,
                 SiopOpenId4Vp {}
         }
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/ClientMetaDataValidator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/ClientMetaDataValidator.kt
@@ -27,7 +27,6 @@ import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import kotlinx.serialization.json.JsonObject
-import java.io.IOException
 import java.net.URL
 import java.text.ParseException
 
@@ -77,9 +76,7 @@ internal class ClientMetaDataValidator(private val httpClient: HttpClient) {
         suspend fun requiredJwksUri() = try {
             val unparsed = httpClient.get(URL(jwksUri)).body<String>()
             JWKSet.parse(unparsed)
-        } catch (ex: IOException) {
-            throw ClientMetadataJwkResolutionFailed(ex).asException()
-        } catch (ex: ParseException) {
+        } catch (ex: Throwable) {
             throw ClientMetadataJwkResolutionFailed(ex).asException()
         }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/ClientMetaDataValidator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/ClientMetaDataValidator.kt
@@ -92,7 +92,7 @@ internal class ClientMetaDataValidator(private val httpClient: HttpClient) {
     }
 }
 
-private fun ResponseMode.isJarm() = when (this) {
+internal fun ResponseMode.isJarm() = when (this) {
     is ResponseMode.DirectPost -> false
     is ResponseMode.DirectPostJwt -> true
     is ResponseMode.Fragment -> false

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultAuthorizationRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultAuthorizationRequestResolver.kt
@@ -194,6 +194,8 @@ internal class DefaultAuthorizationRequestResolver(
                 authenticateRequest(fetchedRequest)
             } catch (e: AuthorizationRequestException) {
                 return resolution(fetchedRequest, e.error)
+            } catch (e: ClientRequestException) {
+                return resolution(fetchedRequest, HttpError(e))
             }
 
         val validatedRequestObject =
@@ -208,12 +210,17 @@ internal class DefaultAuthorizationRequestResolver(
                 resolveClientMetaData(validatedRequestObject)
             } catch (e: AuthorizationRequestException) {
                 return resolution(validatedRequestObject, null, e.error)
+            } catch (e: ClientRequestException) {
+                return resolution(validatedRequestObject, null, HttpError(e))
             }
+
         val resolved =
             try {
                 resolveRequestObject(validatedRequestObject, clientMetaData)
             } catch (e: AuthorizationRequestException) {
                 return resolution(validatedRequestObject, clientMetaData, e.error)
+            } catch (e: ClientRequestException) {
+                return resolution(validatedRequestObject, clientMetaData, HttpError(e))
             }
 
         return Resolution.Success(resolved)

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultAuthorizationRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultAuthorizationRequestResolver.kt
@@ -180,7 +180,6 @@ internal class DefaultAuthorizationRequestResolver(
         }
 
     private suspend fun HttpClient.resolveRequestUri(uri: String): Resolution {
-
         val fetchedRequest =
             try {
                 fetchRequest(uri)
@@ -204,7 +203,6 @@ internal class DefaultAuthorizationRequestResolver(
                 return resolution(authenticatedRequest, e.error)
             }
 
-
         val clientMetaData =
             try {
                 resolveClientMetaData(validatedRequestObject)
@@ -215,12 +213,11 @@ internal class DefaultAuthorizationRequestResolver(
             try {
                 resolveRequestObject(validatedRequestObject, clientMetaData)
             } catch (e: AuthorizationRequestException) {
-               return resolution(validatedRequestObject, clientMetaData,  e.error)
+                return resolution(validatedRequestObject, clientMetaData, e.error)
             }
 
         return Resolution.Success(resolved)
     }
-
 
     private suspend fun HttpClient.fetchRequest(uri: String): FetchedRequest {
         val unvalidatedRequest = UnvalidatedRequest.make(uri).getOrThrow()
@@ -241,30 +238,29 @@ internal class DefaultAuthorizationRequestResolver(
 
     private suspend fun HttpClient.resolveRequestObject(
         validatedRequestObject: ValidatedRequestObject,
-        clientMetaData: ValidatedClientMetaData?
+        clientMetaData: ValidatedClientMetaData?,
     ): ResolvedRequestObject {
         val requestObjectResolver = RequestObjectResolver(siopOpenId4VPConfig, this)
         return requestObjectResolver.resolveRequestObject(validatedRequestObject, clientMetaData)
     }
-
 }
 
-
 private fun resolution(uri: String, error: AuthorizationRequestError): Resolution.Invalid {
-   return Resolution.Invalid(error, null)
+    return Resolution.Invalid(error, null)
 }
 
 private fun resolution(fetchedRequest: FetchedRequest, error: AuthorizationRequestError): Resolution.Invalid {
-
+    return Resolution.Invalid(error, null)
 }
 
 private fun resolution(authenticatedRequest: AuthenticatedRequest, error: AuthorizationRequestError): Resolution.Invalid {
-    TODO()
+    return Resolution.Invalid(error, null)
 }
 
-private fun resolution(validatedRequestObject: ValidatedRequestObject,
-                       clientMetaData: ValidatedClientMetaData?,
-                       error: AuthorizationRequestError
+private fun resolution(
+    validatedRequestObject: ValidatedRequestObject,
+    clientMetaData: ValidatedClientMetaData?,
+    error: AuthorizationRequestError,
 ): Resolution.Invalid {
-    TODO()
+    return Resolution.Invalid(error, null)
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultAuthorizationRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultAuthorizationRequestResolver.kt
@@ -408,7 +408,7 @@ private fun JWTClaimsSet.errorDispatchDetails(): ErrorDispatchDetails? =
                     responseMode = responseMode,
                     nonce = getStringClaim("nonce"),
                     state = getStringClaim("state"),
-                    clientId = getStringClaim("client_id")?.let { VerifierId.parse(it).getOrThrow() },
+                    clientId = getStringClaim("client_id")?.let { VerifierId.parse(it).getOrNull() },
                     jarmRequirement = null,
                 )
             }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultAuthorizationRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultAuthorizationRequestResolver.kt
@@ -273,7 +273,7 @@ private fun resolution(fetchedRequest: FetchedRequest, error: AuthorizationReque
     val dispatchDetails = when (fetchedRequest) {
         is FetchedRequest.JwtSecured -> fetchedRequest.jwt.jwtClaimsSet.errorDispatchDetails()
         is FetchedRequest.Plain -> fetchedRequest.requestObject.responseMode()
-            ?.takeIf { !it.requiresJarm() }
+            ?.takeIf { !it.isJarm() }
             ?.let { responseMode ->
                 ErrorDispatchDetails(
                     responseMode = responseMode,
@@ -300,7 +300,7 @@ private fun resolution(
     error: AuthorizationRequestError,
 ): Resolution.Invalid {
     val dispatchDetails = authenticatedRequest.requestObject.responseMode()
-        ?.takeIf { !it.requiresJarm() }
+        ?.takeIf { !it.isJarm() }
         ?.let { responseMode ->
             ErrorDispatchDetails(
                 responseMode = responseMode,
@@ -331,7 +331,7 @@ private fun resolution(
 ): Resolution.Invalid {
     val dispatchDetails = run {
         val responseMode = validatedRequestObject.responseMode
-        if (!responseMode.requiresJarm()) {
+        if (!responseMode.isJarm()) {
             ErrorDispatchDetails(
                 responseMode = responseMode,
                 nonce = validatedRequestObject.nonce,
@@ -388,19 +388,6 @@ private fun UnvalidatedRequestObject.clientId(): VerifierId? =
         VerifierId.parse(it).getOrNull()
     }
 
-private fun ResponseMode.requiresJarm(): Boolean =
-    when (this) {
-        is ResponseMode.Query,
-        is ResponseMode.Fragment,
-        is ResponseMode.DirectPost,
-        -> false
-
-        is ResponseMode.QueryJwt,
-        is ResponseMode.FragmentJwt,
-        is ResponseMode.DirectPostJwt,
-        -> true
-    }
-
 private val AuthenticatedClient.clientId: VerifierId
     get() = when (this) {
         is AuthenticatedClient.Attested -> VerifierId(ClientIdScheme.VERIFIER_ATTESTATION, clientId)
@@ -430,7 +417,7 @@ private fun JWTClaimsSet.responseMode(): ResponseMode? =
 private fun JWTClaimsSet.errorDispatchDetails(): ErrorDispatchDetails? =
     runCatching {
         responseMode()
-            ?.takeIf { !it.requiresJarm() }
+            ?.takeIf { !it.isJarm() }
             ?.let { responseMode ->
                 ErrorDispatchDetails(
                     responseMode = responseMode,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectResolver.kt
@@ -26,7 +26,6 @@ internal class RequestObjectResolver(
     httpClient: HttpClient,
 ) {
     private val presentationDefinitionResolver = PresentationDefinitionResolver(siopOpenId4VPConfig, httpClient)
-    private val clientMetaDataValidator = ClientMetaDataValidator(httpClient)
 
     suspend fun resolveRequestObject(validated: ValidatedRequestObject, clientMetaData: ValidatedClientMetaData?): ResolvedRequestObject {
         return when (validated) {
@@ -131,11 +130,6 @@ internal class RequestObjectResolver(
         }
         throw ResolutionError.UnknownScope(scope).asException()
     }
-
-    private suspend fun resolveClientMetaData(validated: ValidatedRequestObject): ValidatedClientMetaData? =
-        validated.clientMetaData?.let { unvalidated ->
-            clientMetaDataValidator.validateClientMetaData(unvalidated, validated.responseMode)
-        }
 
     private fun resolveTransactionData(query: PresentationQuery, unresolvedTransactionData: List<String>): List<TransactionData> =
         runCatching {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectResolver.kt
@@ -28,8 +28,7 @@ internal class RequestObjectResolver(
     private val presentationDefinitionResolver = PresentationDefinitionResolver(siopOpenId4VPConfig, httpClient)
     private val clientMetaDataValidator = ClientMetaDataValidator(httpClient)
 
-    suspend fun resolveRequestObject(validated: ValidatedRequestObject): ResolvedRequestObject {
-        val clientMetaData = resolveClientMetaData(validated)
+    suspend fun resolveRequestObject(validated: ValidatedRequestObject, clientMetaData: ValidatedClientMetaData?): ResolvedRequestObject {
         return when (validated) {
             is SiopAuthentication -> resolveIdTokenRequest(validated, clientMetaData)
             is OpenId4VPAuthorization -> resolveVpTokenRequest(validated, clientMetaData)

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponse.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponse.kt
@@ -27,12 +27,10 @@ internal sealed interface AuthorizationResponsePayload : Serializable {
 
     val nonce: String?
     val state: String?
+    val clientId: VerifierId?
     val encryptionParameters: EncryptionParameters?
 
-    sealed interface Positive : AuthorizationResponsePayload {
-        override val nonce: String
-        val clientId: VerifierId
-    }
+    sealed interface Success : AuthorizationResponsePayload
 
     /**
      * In response to a [ResolvedRequestObject.SiopAuthentication]
@@ -47,7 +45,7 @@ internal sealed interface AuthorizationResponsePayload : Serializable {
         override val state: String?,
         override val clientId: VerifierId,
         override val encryptionParameters: EncryptionParameters? = null,
-    ) : Positive
+    ) : Success
 
     /**
      * In response to a [ResolvedRequestObject.OpenId4VPAuthorization]
@@ -64,7 +62,7 @@ internal sealed interface AuthorizationResponsePayload : Serializable {
         override val state: String?,
         override val clientId: VerifierId,
         override val encryptionParameters: EncryptionParameters? = null,
-    ) : Positive
+    ) : Success
 
     /**
      * In response to a [ResolvedRequestObject.SiopOpenId4VPAuthentication]
@@ -83,12 +81,9 @@ internal sealed interface AuthorizationResponsePayload : Serializable {
         override val state: String?,
         override val clientId: VerifierId,
         override val encryptionParameters: EncryptionParameters? = null,
-    ) : Positive
+    ) : Success
 
-    sealed interface Negative : AuthorizationResponsePayload {
-        override val nonce: String
-        val clientId: VerifierId
-    }
+    sealed interface Failed : AuthorizationResponsePayload
 
     /**
      * In response of a [ResolvedRequestObject] and
@@ -100,9 +95,7 @@ internal sealed interface AuthorizationResponsePayload : Serializable {
         override val state: String?,
         override val clientId: VerifierId,
         override val encryptionParameters: EncryptionParameters? = null,
-    ) : Negative
-
-    sealed interface Error : AuthorizationResponsePayload
+    ) : Failed
 
     /**
      * In response of an [Resolution.Invalid] authorization request
@@ -113,8 +106,9 @@ internal sealed interface AuthorizationResponsePayload : Serializable {
         val error: AuthorizationRequestError,
         override val nonce: String?,
         override val state: String?,
+        override val clientId: VerifierId?,
         override val encryptionParameters: EncryptionParameters? = null,
-    ) : Error
+    ) : Failed
 }
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponse.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponse.kt
@@ -25,12 +25,14 @@ import java.net.URL
  */
 internal sealed interface AuthorizationResponsePayload : Serializable {
 
-    val nonce: String
+    val nonce: String?
     val state: String?
-    val clientId: VerifierId
     val encryptionParameters: EncryptionParameters?
 
-    sealed interface Success : AuthorizationResponsePayload
+    sealed interface Positive : AuthorizationResponsePayload {
+        override val nonce: String
+        val clientId: VerifierId
+    }
 
     /**
      * In response to a [ResolvedRequestObject.SiopAuthentication]
@@ -45,7 +47,7 @@ internal sealed interface AuthorizationResponsePayload : Serializable {
         override val state: String?,
         override val clientId: VerifierId,
         override val encryptionParameters: EncryptionParameters? = null,
-    ) : Success
+    ) : Positive
 
     /**
      * In response to a [ResolvedRequestObject.OpenId4VPAuthorization]
@@ -62,7 +64,7 @@ internal sealed interface AuthorizationResponsePayload : Serializable {
         override val state: String?,
         override val clientId: VerifierId,
         override val encryptionParameters: EncryptionParameters? = null,
-    ) : Success
+    ) : Positive
 
     /**
      * In response to a [ResolvedRequestObject.SiopOpenId4VPAuthentication]
@@ -81,22 +83,12 @@ internal sealed interface AuthorizationResponsePayload : Serializable {
         override val state: String?,
         override val clientId: VerifierId,
         override val encryptionParameters: EncryptionParameters? = null,
-    ) : Success
+    ) : Positive
 
-    sealed interface Failed : AuthorizationResponsePayload
-
-    /**
-     * In response of an [Resolution.Invalid] authorization request
-     * @param error the cause
-     * @param state the state of the request
-     */
-    data class InvalidRequest(
-        val error: AuthorizationRequestError,
-        override val nonce: String,
-        override val state: String?,
-        override val clientId: VerifierId,
-        override val encryptionParameters: EncryptionParameters? = null,
-    ) : Failed
+    sealed interface Negative : AuthorizationResponsePayload {
+        override val nonce: String
+        val clientId: VerifierId
+    }
 
     /**
      * In response of a [ResolvedRequestObject] and
@@ -108,7 +100,21 @@ internal sealed interface AuthorizationResponsePayload : Serializable {
         override val state: String?,
         override val clientId: VerifierId,
         override val encryptionParameters: EncryptionParameters? = null,
-    ) : Failed
+    ) : Negative
+
+    sealed interface Error : AuthorizationResponsePayload
+
+    /**
+     * In response of an [Resolution.Invalid] authorization request
+     * @param error the cause
+     * @param state the state of the request
+     */
+    data class InvalidRequest(
+        val error: AuthorizationRequestError,
+        override val nonce: String?,
+        override val state: String?,
+        override val encryptionParameters: EncryptionParameters? = null,
+    ) : Error
 }
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultResponseDispatcher.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultResponseDispatcher.kt
@@ -60,10 +60,10 @@ internal class DefaultDispatcher(
 
     override suspend fun post(
         error: AuthorizationRequestError,
-        di: ErrorDispatchDetails,
-        encryptionParameters: EncryptionParameters?
+        errorDispatchDetails: ErrorDispatchDetails,
+        encryptionParameters: EncryptionParameters?,
     ): DispatchOutcome.VerifierResponse {
-        val response = error.responseWith(di, encryptionParameters)
+        val response = error.responseWith(errorDispatchDetails, encryptionParameters)
         val (responseUri, parameters) = formParameters(response)
         return httpClientFactory().use { httpClient ->
             submitForm(httpClient, responseUri, parameters)
@@ -71,7 +71,7 @@ internal class DefaultDispatcher(
     }
 
     private fun formParameters(
-        response: AuthorizationResponse
+        response: AuthorizationResponse,
     ): Pair<URL, Parameters> =
         when (response) {
             is DirectPost -> {
@@ -131,15 +131,15 @@ internal class DefaultDispatcher(
 
     override suspend fun encodeRedirectURI(
         error: AuthorizationRequestError,
-        di: ErrorDispatchDetails,
-        encryptionParameters: EncryptionParameters?
+        errorDispatchDetails: ErrorDispatchDetails,
+        encryptionParameters: EncryptionParameters?,
     ): DispatchOutcome.RedirectURI {
-        val response = error.responseWith(di, encryptionParameters)
+        val response = error.responseWith(errorDispatchDetails, encryptionParameters)
         return encodeRedirectURI(response)
     }
 
     private fun encodeRedirectURI(
-        response: AuthorizationResponse
+        response: AuthorizationResponse,
     ): DispatchOutcome.RedirectURI {
         val uri = when (response) {
             is Fragment -> response.encodeRedirectURI()

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultResponseDispatcher.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultResponseDispatcher.kt
@@ -44,25 +44,36 @@ import java.net.URL
 internal class DefaultDispatcher(
     private val siopOpenId4VPConfig: SiopOpenId4VPConfig,
     private val httpClientFactory: KtorHttpClientFactory,
-) : Dispatcher {
+) : Dispatcher, ErrorDispatcher {
 
     override suspend fun post(
         request: ResolvedRequestObject,
         consensus: Consensus,
         encryptionParameters: EncryptionParameters?,
     ): DispatchOutcome.VerifierResponse {
-        val (responseUri, parameters) = formParameters(request, consensus, encryptionParameters)
+        val response = request.responseWith(consensus, encryptionParameters)
+        val (responseUri, parameters) = formParameters(response)
+        return httpClientFactory().use { httpClient ->
+            submitForm(httpClient, responseUri, parameters)
+        }
+    }
+
+    override suspend fun post(
+        error: AuthorizationRequestError,
+        di: ErrorDispatchDetails,
+        encryptionParameters: EncryptionParameters?
+    ): DispatchOutcome.VerifierResponse {
+        val response = error.responseWith(di, encryptionParameters)
+        val (responseUri, parameters) = formParameters(response)
         return httpClientFactory().use { httpClient ->
             submitForm(httpClient, responseUri, parameters)
         }
     }
 
     private fun formParameters(
-        request: ResolvedRequestObject,
-        consensus: Consensus,
-        encryptionParameters: EncryptionParameters?,
+        response: AuthorizationResponse
     ): Pair<URL, Parameters> =
-        when (val response = request.responseWith(consensus, encryptionParameters)) {
+        when (response) {
             is DirectPost -> {
                 val parameters = DirectPostForm.parametersOf(response.data)
                 response.responseUri to parameters
@@ -114,13 +125,30 @@ internal class DefaultDispatcher(
         consensus: Consensus,
         encryptionParameters: EncryptionParameters?,
     ): DispatchOutcome.RedirectURI {
-        val uri = when (val response = request.responseWith(consensus, encryptionParameters)) {
+        val response = request.responseWith(consensus, encryptionParameters)
+        return encodeRedirectURI(response)
+    }
+
+    override suspend fun encodeRedirectURI(
+        error: AuthorizationRequestError,
+        di: ErrorDispatchDetails,
+        encryptionParameters: EncryptionParameters?
+    ): DispatchOutcome.RedirectURI {
+        val response = error.responseWith(di, encryptionParameters)
+        return encodeRedirectURI(response)
+    }
+
+    private fun encodeRedirectURI(
+        response: AuthorizationResponse
+    ): DispatchOutcome.RedirectURI {
+        val uri = when (response) {
             is Fragment -> response.encodeRedirectURI()
             is FragmentJwt -> response.encodeRedirectURI(siopOpenId4VPConfig)
             is Query -> response.encodeRedirectURI()
             is QueryJwt -> response.encodeRedirectURI(siopOpenId4VPConfig)
             else -> error("Unexpected response $response")
         }
+
         return DispatchOutcome.RedirectURI(uri)
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultResponseDispatcher.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultResponseDispatcher.kt
@@ -61,7 +61,7 @@ internal class DefaultDispatcher(
         request: ResolvedRequestObject,
         consensus: Consensus,
         encryptionParameters: EncryptionParameters?,
-    ) =
+    ): Pair<URL, Parameters> =
         when (val response = request.responseWith(consensus, encryptionParameters)) {
             is DirectPost -> {
                 val parameters = DirectPostForm.parametersOf(response.data)

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultResponseDispatcher.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultResponseDispatcher.kt
@@ -52,10 +52,7 @@ internal class DefaultDispatcher(
         encryptionParameters: EncryptionParameters?,
     ): DispatchOutcome.VerifierResponse {
         val response = request.responseWith(consensus, encryptionParameters)
-        val (responseUri, parameters) = formParameters(response)
-        return httpClientFactory().use { httpClient ->
-            submitForm(httpClient, responseUri, parameters)
-        }
+        return doPost(response)
     }
 
     override suspend fun post(
@@ -64,6 +61,10 @@ internal class DefaultDispatcher(
         encryptionParameters: EncryptionParameters?,
     ): DispatchOutcome.VerifierResponse {
         val response = error.responseWith(errorDispatchDetails, encryptionParameters)
+        return doPost(response)
+    }
+
+    private suspend fun doPost(response: AuthorizationResponse): DispatchOutcome.VerifierResponse {
         val (responseUri, parameters) = formParameters(response)
         return httpClientFactory().use { httpClient ->
             submitForm(httpClient, responseUri, parameters)

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/ErrorResponse.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/ErrorResponse.kt
@@ -28,6 +28,7 @@ internal fun AuthorizationRequestError.responseWith(
         error = this,
         state = di.state,
         nonce = di.nonce,
+        clientId = di.clientId,
         encryptionParameters = encryptionParameters,
     )
     return responseWith(di, payload)

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/ErrorResponse.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/ErrorResponse.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package eu.europa.ec.eudi.openid4vp.internal.response
 
 import eu.europa.ec.eudi.openid4vp.AuthorizationRequestError
@@ -13,7 +28,7 @@ internal fun AuthorizationRequestError.responseWith(
         error = this,
         state = di.state,
         nonce = di.nonce,
-        encryptionParameters = encryptionParameters
+        encryptionParameters = encryptionParameters,
     )
     return responseWith(di, payload)
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/ErrorResponse.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/ErrorResponse.kt
@@ -1,0 +1,35 @@
+package eu.europa.ec.eudi.openid4vp.internal.response
+
+import eu.europa.ec.eudi.openid4vp.AuthorizationRequestError
+import eu.europa.ec.eudi.openid4vp.EncryptionParameters
+import eu.europa.ec.eudi.openid4vp.ErrorDispatchDetails
+import eu.europa.ec.eudi.openid4vp.ResponseMode
+
+internal fun AuthorizationRequestError.responseWith(
+    di: ErrorDispatchDetails,
+    encryptionParameters: EncryptionParameters?,
+): AuthorizationResponse {
+    val payload = AuthorizationResponsePayload.InvalidRequest(
+        error = this,
+        state = di.state,
+        nonce = di.nonce,
+        encryptionParameters = encryptionParameters
+    )
+    return responseWith(di, payload)
+}
+
+private fun responseWith(
+    di: ErrorDispatchDetails,
+    data: AuthorizationResponsePayload.InvalidRequest,
+): AuthorizationResponse {
+    fun jarmOption() = checkNotNull(di.jarmRequirement)
+
+    return when (val mode = di.responseMode) {
+        is ResponseMode.DirectPost -> AuthorizationResponse.DirectPost(mode.responseURI, data)
+        is ResponseMode.DirectPostJwt -> AuthorizationResponse.DirectPostJwt(mode.responseURI, data, jarmOption())
+        is ResponseMode.Fragment -> AuthorizationResponse.Fragment(mode.redirectUri, data)
+        is ResponseMode.FragmentJwt -> AuthorizationResponse.FragmentJwt(mode.redirectUri, data, jarmOption())
+        is ResponseMode.Query -> AuthorizationResponse.Query(mode.redirectUri, data)
+        is ResponseMode.QueryJwt -> AuthorizationResponse.QueryJwt(mode.redirectUri, data, jarmOption())
+    }
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/JarmJwt.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/JarmJwt.kt
@@ -155,7 +155,11 @@ private object JwtPayloadFactory {
     ): JWTClaimsSet =
         buildJsonObject {
             issuer?.let { put("iss", it.value) }
-            put("aud", data.clientId.toString())
+            when(data) {
+                is AuthorizationResponsePayload.Positive -> put("aud", data.clientId.toString())
+                is AuthorizationResponsePayload.Negative -> put("aud", data.clientId.toString())
+                is AuthorizationResponsePayload.InvalidRequest -> {}
+            }
             ttl?.let {
                 val exp = issuedAt.plusMillis(ttl.toMillis()).epochSecond
                 put("exp", exp)

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/JarmJwt.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/JarmJwt.kt
@@ -155,7 +155,7 @@ private object JwtPayloadFactory {
     ): JWTClaimsSet =
         buildJsonObject {
             issuer?.let { put("iss", it.value) }
-            when(data) {
+            when (data) {
                 is AuthorizationResponsePayload.Positive -> put("aud", data.clientId.toString())
                 is AuthorizationResponsePayload.Negative -> put("aud", data.clientId.toString())
                 is AuthorizationResponsePayload.InvalidRequest -> {}

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/JarmJwt.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/JarmJwt.kt
@@ -155,11 +155,7 @@ private object JwtPayloadFactory {
     ): JWTClaimsSet =
         buildJsonObject {
             issuer?.let { put("iss", it.value) }
-            when (data) {
-                is AuthorizationResponsePayload.Positive -> put("aud", data.clientId.toString())
-                is AuthorizationResponsePayload.Negative -> put("aud", data.clientId.toString())
-                is AuthorizationResponsePayload.InvalidRequest -> {}
-            }
+            data.clientId?.let { put("aud", data.clientId.toString()) }
             ttl?.let {
                 val exp = issuedAt.plusMillis(ttl.toMillis()).epochSecond
                 put("exp", exp)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
@@ -692,6 +692,7 @@ class DefaultDispatcherTest {
                         MissingNonce,
                         generateNonce(),
                         state,
+                        VerifierId(ClientIdScheme.PreRegistered, "client_id"),
                     )
                 val response = AuthorizationResponse.Query(redirectUriBase, data)
                 val redirectURI = response.encodeRedirectURI()
@@ -811,6 +812,7 @@ class DefaultDispatcherTest {
                         MissingNonce,
                         generateNonce(),
                         state,
+                        VerifierId(ClientIdScheme.PreRegistered, "client_id"),
                     )
                 val response = AuthorizationResponse.Fragment(redirectUri = redirectUriBase, data = data)
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
@@ -692,7 +692,6 @@ class DefaultDispatcherTest {
                         MissingNonce,
                         generateNonce(),
                         state,
-                        VerifierId(ClientIdScheme.PreRegistered, "client_id"),
                     )
                 val response = AuthorizationResponse.Query(redirectUriBase, data)
                 val redirectURI = response.encodeRedirectURI()
@@ -812,7 +811,6 @@ class DefaultDispatcherTest {
                         MissingNonce,
                         generateNonce(),
                         state,
-                        VerifierId(ClientIdScheme.PreRegistered, "client_id"),
                     )
                 val response = AuthorizationResponse.Fragment(redirectUri = redirectUriBase, data = data)
 


### PR DESCRIPTION
This PR introduces a way to dispatch errors to Verifiers.

Errors are classified into two categories:
1. Non dispatchable: Errors which cannot be dispatched because critical dispatch information in the Authorization Request was either malformed or missing
2. Dispatchable: Errors that can be dispatched. In such cases the Authorization Request was malformed, but critical dispatch information was correct.

The library introduces a new method in Dispatcher to support dispatching of dispatchable errors.

Closes #328 