### PR TITLE
v1 updates for Client Id Prefix.

### DIFF
--- a/Module.md
+++ b/Module.md
@@ -107,19 +107,19 @@ Library currently supports `response_mode`
 * `query.jwt`
 
 
-### Supported Client ID Schemes
+### Supported Client ID Prefixes
 
-Library requires the presence of a `client_id` using one of the following schemes:
+Library requires the presence of a `client_id` using one of the following prefixes:
 
 - `pre-registered` assuming out of bound knowledge of verifier meta-data. A verifier may send an authorization request signed (JAR) or plain
-- `x509_san_dns` where verifier must send the authorization request signed (JAR) using by a suitable X509 certificate
-- `x509_san_uri` where verifier must send the authorization request signed (JAR) using by a suitable X509 certificate
 - `redirect_uri` where verifier must send the authorization request in plain (JAR cannot be used)
-- `did` where verifier must send the authorization request signed (JAR) using a key resolvable via DID URL.
-- `verifier_attestation` where verifier must send the authorization request signed (JAR), witch contains a verifier attestation JWT from a trusted issuer
+- `decentralized_identifier` where verifier must send the authorization request signed (JAR) using a key resolvable via DID URL.
+- `verifier_attestation` where verifier must send the authorization request signed (JAR), which contains a verifier attestation JWT from a trusted issuer
+- `x509_san_dns` where verifier must send the authorization request signed (JAR) using by a suitable X509 certificate
+- `x509_hash` where verifier must send the authorization request signed (JAR) using by a suitable X509 certificate
 
 > [!NOTE]
-> The Client ID Scheme is encoded as a prefix in `client_id`. Absence of such a prefix, indicates the usage of the `pre-registered` Client ID Scheme.
+> The Client ID Prefix is encoded as a prefix in `client_id`. Absence of such a prefix, indicates the usage of the `pre-registered` Client ID Prefix.
 
 ### Retrieving Authorization Request
 

--- a/README.md
+++ b/README.md
@@ -27,23 +27,23 @@ and [OpenId4VP](https://openid.net/specs/openid-4-verifiable-presentations-1_0.h
 In particular, the library focus on the wallet's role using those two protocols with constraints
 included in ISO 23220-4 and ISO-18013-7 and provides the following features:
 
-| Feature                                                                                                                   | Coverage                                                                                                 |
-|---------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-| [Verifiable Presentations Authorization Requests](#resolve-an-authorization-request-uri)                                  | ✅                                                                                                        |
-| Self-Issued OpenID Provider Authorization Requests                                                                        | ✅                                                                                                        |
-| Client authentication schemes                                                                                             | ✅ pre-registered, ✅ verifier_attestation, ✅ x509_san_dns, ✅ x509_san_uri, ✅ DID, ✅ redirect_uri, ❌ https |
-| Attestation query dialect                                                                                                 | ✅ DCQL                                                                                                   |
-| Signed/encrypted authorization requests (JAR)                                                                             | ✅                                                                                                        |
-| Scoped authorization requests                                                                                             | ✅                                                                                                        |
-| Request URI Methods                                                                                                       | ✅ GET, ✅ POST                                                                                            |
-| Wallet metadata                                                                                                           | ✅                                                                                                        |
-| [Dispatch positive and negative responses](#dispatch-authorization-response-to-verifier--rp)                              | ✅                                                                                                        |
-| [Dispatch authorization error response to verifier when possible](#dispatch-authorization-error-response-to-verifier--rp) | ✅                                                                                                        |
-| Signed/Encrypted authorization responses (JARM)                                                                           | ✅                                                                                                        |
-| Response modes                                                                                                            | ✅ direct_post, ✅ direct_post.jwt, ✅ query, ✅ query.jwt, ✅ fragment, ✅ fragment.jwt                       |
-| Transaction Data                                                                                                          | ✅                                                                                                        |
-| Verifier Attestation JWT                                                                                                  | ✅                                                                                                        |
-| Digital Credential API                                                                                                    | ❌                                                                                                        |
+| Feature                                                                                                                   | Coverage                                                                                                                               |
+|---------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| [Verifiable Presentations Authorization Requests](#resolve-an-authorization-request-uri)                                  | ✅                                                                                                                                      |
+| Self-Issued OpenID Provider Authorization Requests                                                                        | ✅                                                                                                                                      |
+| Client authentication prefixes                                                                                            | ✅ pre-registered, ✅ redirect_uri, ❌ openid_federation, ✅ decentralized_identifier, ✅ verifier_attestation, ✅ x509_san_dns, ✅ x509_hash |
+| Attestation query dialect                                                                                                 | ✅ DCQL                                                                                                                                 |
+| Signed/encrypted authorization requests (JAR)                                                                             | ✅                                                                                                                                      |
+| Scoped authorization requests                                                                                             | ✅                                                                                                                                      |
+| Request URI Methods                                                                                                       | ✅ GET, ✅ POST                                                                                                                          |
+| Wallet metadata                                                                                                           | ✅                                                                                                                                      |
+| [Dispatch positive and negative responses](#dispatch-authorization-response-to-verifier--rp)                              | ✅                                                                                                                                      |
+| [Dispatch authorization error response to verifier when possible](#dispatch-authorization-error-response-to-verifier--rp) | ✅                                                                                                                                      |
+| Signed/Encrypted authorization responses (JARM)                                                                           | ✅                                                                                                                                      |
+| Response modes                                                                                                            | ✅ direct_post, ✅ direct_post.jwt, ✅ query, ✅ query.jwt, ✅ fragment, ✅ fragment.jwt                                                     |
+| Transaction Data                                                                                                          | ✅                                                                                                                                      |
+| Verifier Attestation JWT                                                                                                  | ✅                                                                                                                                      |
+| Digital Credential API                                                                                                    | ❌                                                                                                                                      |
 
 ## Disclaimer
 
@@ -228,19 +228,19 @@ Library currently supports `response_mode`
 * `query.jwt`
 
 
-### Supported Client ID Schemes
+### Supported Client ID Prefixes
 
-Library requires the presence of a `client_id` using one of the following schemes:
+Library requires the presence of a `client_id` using one of the following prefixes:
 
 - `pre-registered` assuming out of bound knowledge of verifier meta-data. A verifier may send an authorization request signed (JAR) or plain
-- `x509_san_dns` where verifier must send the authorization request signed (JAR) using by a suitable X509 certificate
-- `x509_san_uri` where verifier must send the authorization request signed (JAR) using by a suitable X509 certificate
 - `redirect_uri` where verifier must send the authorization request in plain (JAR cannot be used)
-- `did` where verifier must send the authorization request signed (JAR) using a key resolvable via DID URL.
+- `decentralized_identifier` where verifier must send the authorization request signed (JAR) using a key resolvable via DID URL.
 - `verifier_attestation` where verifier must send the authorization request signed (JAR), witch contains a verifier attestation JWT from a trusted issuer
+- `x509_san_dns` where verifier must send the authorization request signed (JAR) using by a suitable X509 certificate
+- `x509_hash` where verifier must send the authorization request signed (JAR) using by a suitable X509 certificate
 
 > [!NOTE]
-> The Client ID Scheme is encoded as a prefix in `client_id`. Absence of such a prefix, indicates the usage of the `pre-registered` Client ID Scheme.
+> The Client ID Prefix is encoded as a prefix in `client_id`. Absence of such a prefix, indicates the usage of the `pre-registered` Client ID Prefix.
 
 ### Retrieving Authorization Request
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/OpenId4VPSpec.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/OpenId4VPSpec.kt
@@ -64,6 +64,9 @@ object OpenId4VPSpec {
     const val TRANSACTION_DATA_TYPE: String = "type"
     const val TRANSACTION_DATA_CREDENTIAL_IDS: String = "credential_ids"
     const val TRANSACTION_DATA_HASH_ALGORITHMS: String = "transaction_data_hashes_alg"
+
+    const val CLIENT_ID_PREFIXES_SUPPORTED = "client_id_prefixes_supported"
+    const val VP_FORMATS_SUPPORTED = "vp_formats_supported"
 }
 
 object SIOPv2

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/OpenId4VPSpec.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/OpenId4VPSpec.kt
@@ -20,14 +20,14 @@ object OpenId4VPSpec {
     const val RESPONSE_URI = "response_uri"
     const val DCQL_QUERY = "dcql_query"
 
-    const val CLIENT_ID_SCHEME_SEPARATOR = ':'
-    const val CLIENT_ID_SCHEME_PRE_REGISTERED = "pre-registered"
-    const val CLIENT_ID_SCHEME_REDIRECT_URI = "redirect_uri"
-    const val CLIENT_ID_SCHEME_HTTPS = "https"
-    const val CLIENT_ID_SCHEME_DID = "did"
-    const val CLIENT_ID_SCHEME_X509_SAN_URI = "x509_san_uri"
-    const val CLIENT_ID_SCHEME_X509_SAN_DNS = "x509_san_dns"
-    const val CLIENT_ID_SCHEME_VERIFIER_ATTESTATION = "verifier_attestation"
+    const val CLIENT_ID_PREFIX_SEPARATOR = ':'
+    const val CLIENT_ID_PREFIX_PRE_REGISTERED = "pre-registered"
+    const val CLIENT_ID_PREFIX_REDIRECT_URI = "redirect_uri"
+    const val CLIENT_ID_PREFIX_OPENID_FEDERATION = "openid_federation"
+    const val CLIENT_ID_PREFIX_DECENTRALIZED_IDENTIFIER = "decentralized_identifier"
+    const val CLIENT_ID_PREFIX_VERIFIER_ATTESTATION = "verifier_attestation"
+    const val CLIENT_ID_PREFIX_X509_SAN_DNS = "x509_san_dns"
+    const val CLIENT_ID_PREFIX_X509_HASH = "x509_hash"
 
     const val AUTHORIZATION_REQUEST_OBJECT_TYPE = "oauth-authz-req+jwt"
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticator.kt
@@ -32,7 +32,7 @@ import com.nimbusds.jwt.proc.DefaultJWTProcessor
 import com.nimbusds.jwt.proc.JWTClaimsSetVerifier
 import com.nimbusds.jwt.util.DateUtils
 import eu.europa.ec.eudi.openid4vp.*
-import eu.europa.ec.eudi.openid4vp.SupportedClientIdScheme.Preregistered
+import eu.europa.ec.eudi.openid4vp.SupportedClientIdPrefix.Preregistered
 import eu.europa.ec.eudi.openid4vp.internal.*
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -41,12 +41,9 @@ import io.ktor.client.request.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.*
 import java.net.URI
+import java.security.MessageDigest
 import java.security.PublicKey
 import java.security.cert.X509Certificate
 import java.time.Clock
@@ -58,10 +55,10 @@ import kotlin.time.toKotlinDuration
 internal sealed interface AuthenticatedClient {
     data class Preregistered(val preregisteredClient: PreregisteredClient) : AuthenticatedClient
     data class RedirectUri(val clientId: URI) : AuthenticatedClient
+    data class DecentralizedIdentifier(val client: DID, val publicKey: PublicKey) : AuthenticatedClient
+    data class VerifierAttestation(val clientId: OriginalClientId, val claims: VerifierAttestationClaims) : AuthenticatedClient
     data class X509SanDns(val clientId: OriginalClientId, val chain: List<X509Certificate>) : AuthenticatedClient
-    data class X509SanUri(val clientId: URI, val chain: List<X509Certificate>) : AuthenticatedClient
-    data class DIDClient(val client: DID, val publicKey: PublicKey) : AuthenticatedClient
-    data class Attested(val clientId: OriginalClientId, val claims: VerifierAttestationClaims) : AuthenticatedClient
+    data class X509Hash(val clientId: OriginalClientId, val chain: List<X509Certificate>) : AuthenticatedClient
 }
 
 internal data class AuthenticatedRequest(
@@ -98,99 +95,99 @@ internal class ClientAuthenticator(private val siopOpenId4VPConfig: SiopOpenId4V
             is ReceivedRequest.Unsigned -> request.requestObject
         }
 
-        val (originalClientId, clientIdScheme) = originalClientIdAndScheme(requestObject)
-        return when (clientIdScheme) {
+        val (originalClientId, clientIdPrefix) = originalClientIdAndPrefix(requestObject)
+        return when (clientIdPrefix) {
             is Preregistered -> {
-                val registeredClient = clientIdScheme.clients[originalClientId]
+                val registeredClient = clientIdPrefix.clients[originalClientId]
                 ensureNotNull(registeredClient) { RequestValidationError.InvalidClientId.asException() }
                 if (request is ReceivedRequest.Signed) {
                     ensureNotNull(registeredClient.jarConfig) {
-                        invalidScheme("$registeredClient cannot place signed request")
+                        invalidPrefix("$registeredClient cannot place signed request")
                     }
                 }
                 AuthenticatedClient.Preregistered(registeredClient)
             }
 
-            SupportedClientIdScheme.RedirectUri -> {
+            SupportedClientIdPrefix.RedirectUri -> {
                 ensure(request is ReceivedRequest.Unsigned) {
-                    invalidScheme("${clientIdScheme.scheme()} cannot be used in signed request")
+                    invalidPrefix("${clientIdPrefix.prefix()} cannot be used in signed request")
                 }
                 val originalClientIdAsUri =
                     originalClientId.asURI { RequestValidationError.InvalidClientId.asException() }.getOrThrow()
                 AuthenticatedClient.RedirectUri(originalClientIdAsUri)
             }
 
-            is SupportedClientIdScheme.X509SanDns -> {
+            is SupportedClientIdPrefix.DecentralizedIdentifier -> {
                 ensure(request is ReceivedRequest.Signed) {
-                    invalidScheme("${clientIdScheme.scheme()} cannot be used in unsigned request")
-                }
-                val chain = x5c(originalClientId, request, clientIdScheme.trust) {
-                    val dnsNames = sanOfDNSName().getOrNull()
-                    ensureNotNull(dnsNames) { invalidJarJwt("Certificates misses DNS names") }
-                }
-                AuthenticatedClient.X509SanDns(originalClientId, chain)
-            }
-
-            is SupportedClientIdScheme.X509SanUri -> {
-                ensure(request is ReceivedRequest.Signed) {
-                    invalidScheme("${clientIdScheme.scheme()} cannot be used in unsigned request")
-                }
-                val chain = x5c(originalClientId, request, clientIdScheme.trust) {
-                    val dnsNames = sanOfUniformResourceIdentifier().getOrNull()
-                    ensureNotNull(dnsNames) { invalidJarJwt("Certificates misses URI names") }
-                }
-                val originalClientIdAsUri =
-                    originalClientId.asURI { RequestValidationError.InvalidClientId.asException() }.getOrThrow()
-                AuthenticatedClient.X509SanUri(originalClientIdAsUri, chain)
-            }
-
-            is SupportedClientIdScheme.DID -> {
-                ensure(request is ReceivedRequest.Signed) {
-                    invalidScheme("${clientIdScheme.scheme()} cannot be used in unsigned request")
+                    invalidPrefix("${clientIdPrefix.prefix()} cannot be used in unsigned request")
                 }
                 val originalClientIdAsDID = ensureNotNull(DID.parse(originalClientId).getOrNull()) {
                     RequestValidationError.InvalidClientId.asException()
                 }
-                val clientPubKey = lookupKeyByDID(request, originalClientIdAsDID, clientIdScheme.lookup)
-                AuthenticatedClient.DIDClient(originalClientIdAsDID, clientPubKey)
+                val clientPubKey = lookupKeyByDID(request, originalClientIdAsDID, clientIdPrefix.lookup)
+                AuthenticatedClient.DecentralizedIdentifier(originalClientIdAsDID, clientPubKey)
             }
 
-            is SupportedClientIdScheme.VerifierAttestation -> {
+            is SupportedClientIdPrefix.VerifierAttestation -> {
                 ensure(request is ReceivedRequest.Signed) {
-                    invalidScheme("${clientIdScheme.scheme()} cannot be used in unsigned request")
+                    invalidPrefix("${clientIdPrefix.prefix()} cannot be used in unsigned request")
                 }
                 val attestedClaims =
-                    verifierAttestation(siopOpenId4VPConfig.clock, clientIdScheme, request, originalClientId)
-                AuthenticatedClient.Attested(originalClientId, attestedClaims)
+                    verifierAttestation(siopOpenId4VPConfig.clock, clientIdPrefix, request, originalClientId)
+                AuthenticatedClient.VerifierAttestation(originalClientId, attestedClaims)
+            }
+
+            is SupportedClientIdPrefix.X509SanDns -> {
+                ensure(request is ReceivedRequest.Signed) {
+                    invalidPrefix("${clientIdPrefix.prefix()} cannot be used in unsigned request")
+                }
+                val chain = x5c(request, clientIdPrefix.trust)
+
+                val alternativeNames = chain.first().sanOfDNSName().getOrNull()
+                ensureNotNull(alternativeNames) { invalidJarJwt("Certificates misses DNS names") }
+                ensure(originalClientId in alternativeNames) {
+                    invalidJarJwt("ClientId not found in certificate's subject alternative names")
+                }
+
+                AuthenticatedClient.X509SanDns(originalClientId, chain)
+            }
+
+            is SupportedClientIdPrefix.X509Hash -> {
+                ensure(request is ReceivedRequest.Signed) {
+                    invalidPrefix("${clientIdPrefix.prefix()} cannot be used in unsigned request")
+                }
+                val chain = x5c(request, clientIdPrefix.trust)
+
+                val expectedHash = base64UrlNoPadding.encode(
+                    MessageDigest.getInstance("SHA-256").digest(chain.first().encoded),
+                )
+                ensure(expectedHash == originalClientId) {
+                    invalidJarJwt("ClientId does not match leaf certificate's SHA-256 hash")
+                }
+
+                AuthenticatedClient.X509Hash(originalClientId, chain)
             }
         }
     }
 
-    private fun originalClientIdAndScheme(requestObject: UnvalidatedRequestObject): Pair<OriginalClientId, SupportedClientIdScheme> {
+    private fun originalClientIdAndPrefix(requestObject: UnvalidatedRequestObject): Pair<OriginalClientId, SupportedClientIdPrefix> {
         val clientId = ensureNotNull(requestObject.clientId) { RequestValidationError.MissingClientId.asException() }
         val verifierId =
-            VerifierId.parse(clientId).getOrElse { throw invalidScheme("Invalid client_id: ${it.message}") }
-        val supportedClientIdScheme = siopOpenId4VPConfig.supportedClientIdScheme(verifierId.scheme)
-        ensureNotNull(supportedClientIdScheme) { RequestValidationError.UnsupportedClientIdScheme.asException() }
-        return verifierId.originalClientId to supportedClientIdScheme
+            VerifierId.parse(clientId).getOrElse { throw invalidPrefix("Invalid client_id: ${it.message}") }
+        val supportedClientIdPrefix = siopOpenId4VPConfig.supportedClientIdPrefix(verifierId.prefix)
+        ensureNotNull(supportedClientIdPrefix) { RequestValidationError.UnsupportedClientIdPrefix.asException() }
+        return verifierId.originalClientId to supportedClientIdPrefix
     }
 
     private fun x5c(
-        originalClientId: OriginalClientId,
         request: ReceivedRequest.Signed,
         trust: X509CertificateTrust,
-        subjectAlternativeNames: X509Certificate.() -> List<String>,
     ): List<X509Certificate> {
         val jwt = request.ensureSingleSignedRequest()
         val x5c = jwt.header?.x509CertChain
         ensureNotNull(x5c) { invalidJarJwt("Missing x5c") }
         val pubCertChain = x5c.mapNotNull { runCatching { X509CertUtils.parse(it.decode()) }.getOrNull() }
         ensure(pubCertChain.isNotEmpty()) { invalidJarJwt("Invalid x5c") }
-
-        val alternativeNames = pubCertChain[0].subjectAlternativeNames()
-        ensure(originalClientId in alternativeNames) {
-            invalidJarJwt("ClientId not found in certificate's subject alternative names")
-        }
         ensure(trust.isTrusted(pubCertChain)) { invalidJarJwt("Untrusted x5c") }
         return pubCertChain
     }
@@ -228,11 +225,11 @@ private suspend fun lookupKeyByDID(
 
 private fun verifierAttestation(
     clock: Clock,
-    supportedScheme: SupportedClientIdScheme.VerifierAttestation,
+    supportedPrefix: SupportedClientIdPrefix.VerifierAttestation,
     request: ReceivedRequest.Signed,
     originalClientId: OriginalClientId,
 ): VerifierAttestationClaims {
-    val (trust, skew) = supportedScheme
+    val (trust, skew) = supportedPrefix
     fun invalidVerifierAttestationJwt(cause: String?) =
         invalidJarJwt("Invalid VerifierAttestation JWT. Details: $cause")
 
@@ -300,20 +297,20 @@ private class JarJwtSignatureVerifier(
             is AuthenticatedClient.Preregistered ->
                 getPreRegisteredClientJwsSelector(client)
 
-            is AuthenticatedClient.X509SanUri ->
-                JWSKeySelector<SecurityContext> { _, _ -> listOf(client.chain[0].publicKey) }
+            is AuthenticatedClient.RedirectUri ->
+                throw RequestValidationError.UnsupportedClientIdPrefix.asException()
+
+            is AuthenticatedClient.DecentralizedIdentifier ->
+                JWSKeySelector<SecurityContext> { _, _ -> listOf(client.publicKey) }
+
+            is AuthenticatedClient.VerifierAttestation ->
+                JWSKeySelector<SecurityContext> { _, _ -> listOf(client.claims.verifierPubJwk.toPublicKey()) }
 
             is AuthenticatedClient.X509SanDns ->
                 JWSKeySelector<SecurityContext> { _, _ -> listOf(client.chain[0].publicKey) }
 
-            is AuthenticatedClient.RedirectUri ->
-                throw RequestValidationError.UnsupportedClientIdScheme.asException()
-
-            is AuthenticatedClient.DIDClient ->
-                JWSKeySelector<SecurityContext> { _, _ -> listOf(client.publicKey) }
-
-            is AuthenticatedClient.Attested ->
-                JWSKeySelector<SecurityContext> { _, _ -> listOf(client.claims.verifierPubJwk.toPublicKey()) }
+            is AuthenticatedClient.X509Hash ->
+                JWSKeySelector<SecurityContext> { _, _ -> listOf(client.chain[0].publicKey) }
         }
 
     @Throws(AuthorizationRequestException::class)
@@ -342,8 +339,8 @@ private class JarJwtSignatureVerifier(
     }
 }
 
-private fun invalidScheme(cause: String): AuthorizationRequestException =
-    RequestValidationError.InvalidClientIdScheme(cause).asException()
+private fun invalidPrefix(cause: String): AuthorizationRequestException =
+    RequestValidationError.InvalidClientIdPrefix(cause).asException()
 
 private fun invalidJarJwt(cause: String): AuthorizationRequestException =
     RequestValidationError.InvalidJarJwt(cause).asException()

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
@@ -18,6 +18,7 @@ package eu.europa.ec.eudi.openid4vp.internal.request
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.JWKSet
 import eu.europa.ec.eudi.openid4vp.EncryptionRequirement
+import eu.europa.ec.eudi.openid4vp.OpenId4VPSpec
 import eu.europa.ec.eudi.openid4vp.SiopOpenId4VPConfig
 import eu.europa.ec.eudi.openid4vp.internal.toJsonObject
 import kotlinx.serialization.json.*
@@ -27,8 +28,6 @@ private const val JWKS = "jwks"
 private const val AUTHORIZATION_ENCRYPTION_ALG_VALUES_SUPPORTED = "authorization_encryption_alg_values_supported"
 private const val AUTHORIZATION_ENCRYPTION_ENC_VALUES_SUPPORTED = "authorization_encryption_enc_values_supported"
 
-private const val CLIENT_ID_PREFIXES_SUPPORTED = "client_id_prefixes_supported"
-private const val VP_FORMATS_SUPPORTED = "vp_formats_supported"
 private const val RESPONSE_TYPES_SUPPOERTED = "response_types_supported"
 private const val RESPONSE_MODES_SUPPORTED = "response_modes_supported"
 
@@ -64,8 +63,8 @@ internal fun walletMetaData(cfg: SiopOpenId4VPConfig, keys: List<JWK>): JsonObje
         //
         val vpFormats =
             VpFormatsTO.make(cfg.vpConfiguration.vpFormats).let(Json.Default::encodeToJsonElement)
-        put(VP_FORMATS_SUPPORTED, vpFormats)
-        putJsonArray(CLIENT_ID_PREFIXES_SUPPORTED) {
+        put(OpenId4VPSpec.VP_FORMATS_SUPPORTED, vpFormats)
+        putJsonArray(OpenId4VPSpec.CLIENT_ID_PREFIXES_SUPPORTED) {
             cfg.supportedClientIdPrefixes.forEach { supportedClientIdPrefix ->
                 add(supportedClientIdPrefix.prefix().value())
             }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
@@ -27,7 +27,7 @@ private const val JWKS = "jwks"
 private const val AUTHORIZATION_ENCRYPTION_ALG_VALUES_SUPPORTED = "authorization_encryption_alg_values_supported"
 private const val AUTHORIZATION_ENCRYPTION_ENC_VALUES_SUPPORTED = "authorization_encryption_enc_values_supported"
 
-private const val CLIENT_ID_SCHEMES_SUPPORTED = "client_id_schemes_supported"
+private const val CLIENT_ID_PREFIXES_SUPPORTED = "client_id_prefixes_supported"
 private const val VP_FORMATS_SUPPORTED = "vp_formats_supported"
 private const val RESPONSE_TYPES_SUPPOERTED = "response_types_supported"
 private const val RESPONSE_MODES_SUPPORTED = "response_modes_supported"
@@ -65,9 +65,9 @@ internal fun walletMetaData(cfg: SiopOpenId4VPConfig, keys: List<JWK>): JsonObje
         val vpFormats =
             VpFormatsTO.make(cfg.vpConfiguration.vpFormats).let(Json.Default::encodeToJsonElement)
         put(VP_FORMATS_SUPPORTED, vpFormats)
-        putJsonArray(CLIENT_ID_SCHEMES_SUPPORTED) {
-            cfg.supportedClientIdSchemes.forEach { supportedClientIdScheme ->
-                add(supportedClientIdScheme.scheme().value())
+        putJsonArray(CLIENT_ID_PREFIXES_SUPPORTED) {
+            cfg.supportedClientIdPrefixes.forEach { supportedClientIdPrefix ->
+                add(supportedClientIdPrefix.prefix().value())
             }
         }
         putJsonArray(RESPONSE_TYPES_SUPPOERTED) {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationRequestErrorCode.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationRequestErrorCode.kt
@@ -39,11 +39,11 @@ internal enum class AuthorizationRequestErrorCode(val code: String) {
      *
      * DCQL Query does not conform to the OpenId4VP specification.
      *
-     * The Wallet does not support the Client Identifier Scheme passed in the Authorization Request
+     * The Wallet does not support the Client Identifier Prefix passed in the Authorization Request
      *
-     * The Client Identifier passed in the request did not belong to its Client Identifier scheme,
-     * or requirements of a certain scheme was violated,
-     * for example, an unsigned request was sent with Client Identifier scheme https
+     * The Client Identifier passed in the request did not belong to its Client Identifier prefix,
+     * or requirements of a certain prefix was violated,
+     * for example, an unsigned request was sent with Client Identifier prefix openid_federation
      */
     INVALID_REQUEST("invalid_request"),
 
@@ -111,7 +111,7 @@ internal enum class AuthorizationRequestErrorCode(val code: String) {
             return when (error) {
                 is UnknownScope -> INVALID_SCOPE
 
-                is InvalidClientIdScheme,
+                is InvalidClientIdPrefix,
                 InvalidRedirectUri,
                 InvalidResponseUri,
                 MissingClientId,
@@ -139,7 +139,7 @@ internal enum class AuthorizationRequestErrorCode(val code: String) {
                 is InvalidVerifierAttestations,
                 -> INVALID_REQUEST
 
-                InvalidClientId, UnsupportedClientIdScheme -> INVALID_CLIENT
+                InvalidClientId, UnsupportedClientIdPrefix -> INVALID_CLIENT
 
                 is InvalidRequestUriMethod -> INVALID_REQUEST_URI_METHOD
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
@@ -25,8 +25,8 @@ import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.openid.connect.sdk.Nonce
 import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet
-import eu.europa.ec.eudi.openid4vp.SupportedClientIdScheme.Preregistered
-import eu.europa.ec.eudi.openid4vp.SupportedClientIdScheme.X509SanDns
+import eu.europa.ec.eudi.openid4vp.SupportedClientIdPrefix.Preregistered
+import eu.europa.ec.eudi.openid4vp.SupportedClientIdPrefix.X509SanDns
 import eu.europa.ec.eudi.openid4vp.dcql.metaSdJwtVc
 import eu.europa.ec.eudi.openid4vp.internal.base64UrlNoPadding
 import eu.europa.ec.eudi.openid4vp.internal.jsonSupport
@@ -438,7 +438,7 @@ private val TrustAnyX509: (List<X509Certificate>) -> Boolean = { _ ->
     true
 }
 
-private fun walletConfig(vararg supportedClientIdScheme: SupportedClientIdScheme) =
+private fun walletConfig(vararg supportedClientIdPrefix: SupportedClientIdPrefix) =
     SiopOpenId4VPConfig(
         vpConfiguration = VPConfiguration(
             vpFormats = VpFormats(VpFormat.SdJwtVc.ES256, VpFormat.MsoMdoc.ES256),
@@ -465,7 +465,7 @@ private fun walletConfig(vararg supportedClientIdScheme: SupportedClientIdScheme
             supportedAlgorithms = listOf(JWEAlgorithm.ECDH_ES),
             supportedMethods = listOf(EncryptionMethod.A128CBC_HS256, EncryptionMethod.A256GCM),
         ),
-        supportedClientIdSchemes = supportedClientIdScheme,
+        supportedClientIdPrefixes = supportedClientIdPrefix,
         clock = Clock.systemDefaultZone(),
     )
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
@@ -100,8 +100,8 @@ class UnvalidatedRequestResolverTest {
     ).jsonObject
 
     private val walletConfig = SiopOpenId4VPConfig(
-        supportedClientIdSchemes = listOf(
-            SupportedClientIdScheme.Preregistered(
+        supportedClientIdPrefixes = listOf(
+            SupportedClientIdPrefix.Preregistered(
                 PreregisteredClient(
                     clientId = "Verifier",
                     legalName = "Verifier",
@@ -112,9 +112,9 @@ class UnvalidatedRequestResolverTest {
                     ),
                 ),
             ),
-            SupportedClientIdScheme.X509SanDns(::validateChain),
-            SupportedClientIdScheme.X509SanUri(::validateChain),
-            SupportedClientIdScheme.RedirectUri,
+            SupportedClientIdPrefix.RedirectUri,
+            SupportedClientIdPrefix.X509SanDns(::validateChain),
+            SupportedClientIdPrefix.X509Hash(::validateChain),
         ),
         jarConfiguration = JarConfiguration(
             supportedAlgorithms = listOf(JWSAlgorithm.RS256),
@@ -251,7 +251,7 @@ class UnvalidatedRequestResolverTest {
     }
 
     @Test
-    fun `JAR auth request, request passed as JWT, verified with pre-registered client scheme`() = runBlocking {
+    fun `JAR auth request, request passed as JWT, verified with pre-registered client prefix`() = runBlocking {
         suspend fun test(typ: JOSEObjectType? = null, assertions: (Resolution) -> Unit) {
             val jwkSet = JWKSet(signingKey)
             val unvalidatedClientMetaData = UnvalidatedClientMetaData(
@@ -294,7 +294,7 @@ class UnvalidatedRequestResolverTest {
     }
 
     @Test
-    fun `JAR auth request, request passed as JWT, verified with x509_san_dns scheme`() = runTest {
+    fun `JAR auth request, request passed as JWT, verified with x509_san_dns prefix`() = runTest {
         suspend fun test(typ: JOSEObjectType? = null, assertions: (Resolution) -> Unit) {
             val keyStore = KeyStore.getInstance("JKS")
             keyStore.load(
@@ -337,7 +337,7 @@ class UnvalidatedRequestResolverTest {
     }
 
     @Test
-    fun `JAR auth request, request passed as JWT, verified with x509_san_uri scheme`() = runTest {
+    fun `JAR auth request, request passed as JWT, verified with x509_hash prefix`() = runTest {
         suspend fun test(typ: JOSEObjectType? = null, assertions: (Resolution) -> Unit) {
             val keyStore = KeyStore.getInstance("JKS")
             keyStore.load(
@@ -345,7 +345,7 @@ class UnvalidatedRequestResolverTest {
                 "12345".toCharArray(),
 
             )
-            val clientId = "x509_san_uri:https://verifier.example.gr"
+            val clientId = "x509_hash:0Wuix-gyx7KGtmfxusspetyYsnjThtGOpI15s5QVPZQ"
             val clientIdEncoded = URLEncoder.encode(clientId, "UTF-8")
             val jwtClaimsSet = jwtClaimsSet(
                 clientId,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcherTest.kt
@@ -198,7 +198,7 @@ private fun config(clientId: String, jarEncryptionRequirement: EncryptionRequire
         vpConfiguration = VPConfiguration(
             vpFormats = VpFormats(VpFormat.SdJwtVc.ES256, VpFormat.MsoMdoc.ES256),
         ),
-        supportedClientIdSchemes = listOf(SupportedClientIdScheme.Preregistered(PreregisteredClient(clientId, clientId))),
+        supportedClientIdPrefixes = listOf(SupportedClientIdPrefix.Preregistered(PreregisteredClient(clientId, clientId))),
     )
 
 private fun createSignedRequestObject(clientId: String, walletNonce: String): SignedJWT =

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
@@ -33,7 +33,7 @@ class WalletMetaDataTest {
     @Test
     fun `test with jar encryption`() = runTest {
         val config = SiopOpenId4VPConfig(
-            supportedClientIdSchemes = listOf(SupportedClientIdScheme.X509SanDns.NoValidation),
+            supportedClientIdPrefixes = listOf(SupportedClientIdPrefix.X509SanDns.NoValidation),
             vpConfiguration = VPConfiguration(
                 vpFormats = VpFormats(
                     VpFormat.SdJwtVc.ES256,
@@ -57,7 +57,7 @@ class WalletMetaDataTest {
     @Test
     fun `test without jar encryption`() = runTest {
         val config = SiopOpenId4VPConfig(
-            supportedClientIdSchemes = listOf(SupportedClientIdScheme.X509SanDns.NoValidation),
+            supportedClientIdPrefixes = listOf(SupportedClientIdPrefix.X509SanDns.NoValidation),
             vpConfiguration = VPConfiguration(
                 vpFormats = VpFormats(
                     VpFormat.SdJwtVc.ES256,
@@ -89,7 +89,7 @@ private suspend fun assertMetadata(config: SiopOpenId4VPConfig) {
         }
 
     assertExpectedVpFormats(config.vpConfiguration.vpFormats, walletMetaData)
-    assertClientIdScheme(config.supportedClientIdSchemes, walletMetaData)
+    assertClientIdPrefix(config.supportedClientIdPrefixes, walletMetaData)
     assertPresentationDefinitionUriSupported(walletMetaData)
     assertJarSigning(config.jarConfiguration.supportedAlgorithms, walletMetaData)
     assertJarEncryption(encryptionRequirement, ephemeralJarEncryptionJwks, walletMetaData)
@@ -144,19 +144,19 @@ private fun assertPresentationDefinitionUriSupported(walletMetaData: JsonObject)
     }
 }
 
-private fun assertClientIdScheme(
-    supportedClientIdSchemes: List<SupportedClientIdScheme>,
+private fun assertClientIdPrefix(
+    supportedClientIdPrefixes: List<SupportedClientIdPrefix>,
     walletMetaData: JsonObject,
 ) {
-    val schemes = walletMetaData["client_id_schemes_supported"]
-    if (supportedClientIdSchemes.isNotEmpty()) {
-        assertIs<JsonArray>(schemes)
+    val prefixes = walletMetaData["client_id_prefixes_supported"]
+    if (supportedClientIdPrefixes.isNotEmpty()) {
+        assertIs<JsonArray>(prefixes)
         assertContentEquals(
-            supportedClientIdSchemes.map { it.scheme().value() },
-            schemes.mapNotNull { it.jsonPrimitive.contentOrNull },
+            supportedClientIdPrefixes.map { it.prefix().value() },
+            prefixes.mapNotNull { it.jsonPrimitive.contentOrNull },
         )
     } else {
-        assertNull(schemes)
+        assertNull(prefixes)
     }
 }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
@@ -148,7 +148,7 @@ private fun assertClientIdPrefix(
     supportedClientIdPrefixes: List<SupportedClientIdPrefix>,
     walletMetaData: JsonObject,
 ) {
-    val prefixes = walletMetaData["client_id_prefixes_supported"]
+    val prefixes = walletMetaData[OpenId4VPSpec.CLIENT_ID_PREFIXES_SUPPORTED]
     if (supportedClientIdPrefixes.isNotEmpty()) {
         assertIs<JsonArray>(prefixes)
         assertContentEquals(
@@ -165,8 +165,8 @@ private fun assertExpectedVpFormats(
     walletMetaData: JsonObject,
 ) {
     val vpFormats = assertIs<JsonObject>(
-        walletMetaData["vp_formats_supported"],
-        "Missing vp_formats_supported",
+        walletMetaData[OpenId4VPSpec.VP_FORMATS_SUPPORTED],
+        "Missing ${OpenId4VPSpec.VP_FORMATS_SUPPORTED}",
     )
     if (expectedVpFormats.msoMdoc != null) {
         val msoMdoc = assertNotNull(vpFormats["mso_mdoc"])

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponseBuilderTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponseBuilderTest.kt
@@ -46,7 +46,7 @@ class AuthorizationResponseBuilderTest {
     internal object Wallet {
 
         val config = SiopOpenId4VPConfig(
-            supportedClientIdSchemes = listOf(SupportedClientIdScheme.X509SanDns.NoValidation),
+            supportedClientIdPrefixes = listOf(SupportedClientIdPrefix.X509SanDns.NoValidation),
             jarmConfiguration = JarmConfiguration.Encryption(
                 supportedAlgorithms = listOf(JWEAlgorithm.ECDH_ES),
                 supportedMethods = listOf(EncryptionMethod.A256GCM),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponseDispatcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponseDispatcherTest.kt
@@ -69,7 +69,7 @@ class AuthorizationResponseDispatcherTest {
     }
 
     private val walletConfig = SiopOpenId4VPConfig(
-        supportedClientIdSchemes = listOf(SupportedClientIdScheme.X509SanDns.NoValidation),
+        supportedClientIdPrefixes = listOf(SupportedClientIdPrefix.X509SanDns.NoValidation),
         vpConfiguration = VPConfiguration(
             vpFormats = VpFormats(VpFormat.SdJwtVc.ES256, VpFormat.MsoMdoc.ES256),
         ),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
@@ -138,7 +138,7 @@ class DefaultDispatcherTest {
         }
 
         val config = SiopOpenId4VPConfig(
-            supportedClientIdSchemes = listOf(SupportedClientIdScheme.X509SanDns.NoValidation),
+            supportedClientIdPrefixes = listOf(SupportedClientIdPrefix.X509SanDns.NoValidation),
             jarmConfiguration = JarmConfiguration.SigningAndEncryption(
                 signer = JarmSigner(jarmSigningKeyPair),
                 supportedEncryptionAlgorithms = listOf(Verifier.jarmEncryptionKeyPair.algorithm as JWEAlgorithm),
@@ -695,7 +695,7 @@ class DefaultDispatcherTest {
                 val data = AuthorizationResponsePayload.NoConsensusResponseData(
                     generateNonce(),
                     state,
-                    VerifierId(ClientIdScheme.PreRegistered, "client_id"),
+                    VerifierId(ClientIdPrefix.PreRegistered, "client_id"),
                 )
                 val response = AuthorizationResponse.Query(redirectUri = redirectUriBase, data = data)
                 response.encodeRedirectURI()
@@ -716,7 +716,7 @@ class DefaultDispatcherTest {
                         MissingNonce,
                         generateNonce(),
                         state,
-                        VerifierId(ClientIdScheme.PreRegistered, "client_id"),
+                        VerifierId(ClientIdPrefix.PreRegistered, "client_id"),
                     )
                 val response = AuthorizationResponse.Query(redirectUriBase, data)
                 val redirectURI = response.encodeRedirectURI()
@@ -738,7 +738,7 @@ class DefaultDispatcherTest {
                     "dummy",
                     generateNonce(),
                     state,
-                    VerifierId(ClientIdScheme.PreRegistered, "client_id"),
+                    VerifierId(ClientIdPrefix.PreRegistered, "client_id"),
                     EncryptionParameters.DiffieHellman(Base64URL.encode("dummy_apu")),
                 )
                 val response = AuthorizationResponse.Query(redirectUriBase, data)
@@ -760,7 +760,7 @@ class DefaultDispatcherTest {
                     "dummy",
                     generateNonce(),
                     state,
-                    VerifierId(ClientIdScheme.PreRegistered, "client_id"),
+                    VerifierId(ClientIdPrefix.PreRegistered, "client_id"),
                     EncryptionParameters.DiffieHellman(Base64URL.encode("dummy_apu")),
                 )
                 val response = AuthorizationResponse.QueryJwt(
@@ -854,7 +854,7 @@ class DefaultDispatcherTest {
                 val data = AuthorizationResponsePayload.NoConsensusResponseData(
                     generateNonce(),
                     state,
-                    VerifierId(ClientIdScheme.PreRegistered, "client_id"),
+                    VerifierId(ClientIdPrefix.PreRegistered, "client_id"),
                 )
                 val response = AuthorizationResponse.Fragment(redirectUri = redirectUriBase, data = data)
 
@@ -876,7 +876,7 @@ class DefaultDispatcherTest {
                         MissingNonce,
                         generateNonce(),
                         state,
-                        VerifierId(ClientIdScheme.PreRegistered, "client_id"),
+                        VerifierId(ClientIdPrefix.PreRegistered, "client_id"),
                     )
                 val response = AuthorizationResponse.Fragment(redirectUri = redirectUriBase, data = data)
 
@@ -898,7 +898,7 @@ class DefaultDispatcherTest {
                     "dummy",
                     generateNonce(),
                     state,
-                    VerifierId(ClientIdScheme.PreRegistered, "client_id"),
+                    VerifierId(ClientIdPrefix.PreRegistered, "client_id"),
                     EncryptionParameters.DiffieHellman(Base64URL.encode("dummy_apu")),
                 )
                 val response = AuthorizationResponse.Fragment(redirectUri = redirectUriBase, data = data)
@@ -924,7 +924,7 @@ class DefaultDispatcherTest {
                     ),
                     generateNonce(),
                     state,
-                    VerifierId(ClientIdScheme.PreRegistered, "client_id"),
+                    VerifierId(ClientIdPrefix.PreRegistered, "client_id"),
                     EncryptionParameters.DiffieHellman(Base64URL.encode("dummy_apu")),
                 )
                 val response = AuthorizationResponse.Fragment(redirectUri = redirectUriBase, data = data)
@@ -945,7 +945,7 @@ class DefaultDispatcherTest {
                     "dummy",
                     generateNonce(),
                     state,
-                    VerifierId(ClientIdScheme.PreRegistered, "client_id"),
+                    VerifierId(ClientIdPrefix.PreRegistered, "client_id"),
                     EncryptionParameters.DiffieHellman(Base64URL.encode("dummy_apu")),
                 )
                 val response =


### PR DESCRIPTION
1. Renames Client Id Prefix `https` to `openid_federation`
2. Renames Client Id Prefix `did` to `decentralized_identifier`
3. Drops Client Id Prefix `x509_san_uri`
4. Implements Client Id Prefix `x509_hash`
5. Updates Client Id parsing. Now only `pre-registered` Client Id Prefix has *no* prefix in the Client Id
6. Renames `client_id_schemes_supported` Wallet Metadata property to `client_id_prefixes_supported`
7. Aligns naming and ordering with OpenId4VP spec to improve code readability

This PR does not introduce Client Id Prefix `origin`. This Prefix is tightly coupled to DC API and OpenId4VP spec states:
> `origin`: This reserved Client Identifier Prefix is defined in [Appendix A.2](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#dc_api_request). The Wallet MUST NOT accept this Client Identifier Prefix in requests. In OpenID4VP over the Digital Credentials API, the audience of the Credential Presentation is always the origin value prefixed by `origin:`, for example `origin:https://verifier.example.com/`.

Closes #381 

