### PR TITLE
Update Transaction Data

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
@@ -17,8 +17,8 @@ package eu.europa.ec.eudi.openid4vp
 
 import eu.europa.ec.eudi.openid4vp.Client.*
 import eu.europa.ec.eudi.openid4vp.TransactionData.Companion.credentialIds
-import eu.europa.ec.eudi.openid4vp.TransactionData.Companion.hashAlgorithms
 import eu.europa.ec.eudi.openid4vp.TransactionData.Companion.type
+import eu.europa.ec.eudi.openid4vp.TransactionData.SdJwtVc.Companion.hashAlgorithms
 import eu.europa.ec.eudi.openid4vp.dcql.CredentialQueryIds
 import eu.europa.ec.eudi.openid4vp.dcql.DCQL
 import eu.europa.ec.eudi.openid4vp.internal.*
@@ -88,111 +88,137 @@ fun Client.legalName(legalName: X509Certificate.() -> String? = X509Certificate:
     }
 }
 
+typealias Base64UrlSafe = String
+
 /**
  * Represents resolved (i.e., supported by the Wallet) Transaction Data.
  *
+ * @property value the Base64 Url-Safe encoded value of this Transaction Data
  * @property json this Transaction Data as a generic JsonObject
  * @property type the type of the Transaction Data
  * @property credentialIds identifiers of the requested Credentials this Transaction Data is applicable to
- * @property hashAlgorithms Hash Algorithms with which the Hash of this Transaction Data can be calculated
  */
-data class TransactionData private constructor(val value: String) : java.io.Serializable {
-
-    val json: JsonObject by lazy {
-        decode(value)
-    }
-
-    init {
-        json.type()
-        json.hashAlgorithms()
-        json.credentialIds()
-    }
-
+sealed interface TransactionData : java.io.Serializable {
+    val value: Base64UrlSafe
+    val json: JsonObject
     val type: TransactionDataType
-        get() = json.type()
-
     val credentialIds: List<TransactionDataCredentialId>
-        get() = json.credentialIds()
-
-    val hashAlgorithms: List<HashAlgorithm>
-        get() = json.hashAlgorithms()
 
     companion object {
-
-        private val DefaultHashAlgorithm: HashAlgorithm get() = HashAlgorithm.SHA_256
-        private fun decode(s: String): JsonObject {
-            val decoded = base64UrlNoPadding.decodeToByteString(s)
+        private fun decode(value: Base64UrlSafe): JsonObject {
+            val decoded = base64UrlNoPadding.decodeToByteString(value)
             return jsonSupport.decodeFromString(decoded.decodeToString())
         }
 
-        internal fun parse(s: String): Result<TransactionData> = runCatching {
-            TransactionData(s)
-        }
-
         private fun JsonObject.type(): TransactionDataType =
-            TransactionDataType(requiredString(OpenId4VPSpec.TRANSACTION_DATA_TYPE))
+            requiredString(OpenId4VPSpec.TRANSACTION_DATA_TYPE)
+                .let(::TransactionDataType)
 
-        private fun JsonObject.hashAlgorithms(): List<HashAlgorithm> =
-            optionalStringArray(OpenId4VPSpec.TRANSACTION_DATA_HASH_ALGORITHMS)
-                ?.map { HashAlgorithm(it) }
-                ?: listOf(DefaultHashAlgorithm)
+        private fun TransactionData.ensureSupportedType(supportedType: TransactionDataType) {
+            val type = this.type
+            require(type == supportedType) { "Unsupported Transaction Data '${OpenId4VPSpec.TRANSACTION_DATA_TYPE}': '$type'" }
+        }
 
         private fun JsonObject.credentialIds(): List<TransactionDataCredentialId> =
-            requiredStringArray(OpenId4VPSpec.TRANSACTION_DATA_CREDENTIAL_IDS).map { TransactionDataCredentialId(it) }
+            requiredStringArray(OpenId4VPSpec.TRANSACTION_DATA_CREDENTIAL_IDS)
+                .map(::TransactionDataCredentialId)
 
-        private fun TransactionData.isSupported(supportedTypes: List<SupportedTransactionDataType>) {
-            val type = this.type
-            val supportedType = supportedTypes.firstOrNull { it.type == type }
-            requireNotNull(supportedType) { "Unsupported transaction_data '${OpenId4VPSpec.TRANSACTION_DATA_TYPE}': '$type'" }
-
-            val hashAlgorithms = hashAlgorithms.toSet()
-            val supportedHashAlgorithms = supportedType.hashAlgorithms
-            require(supportedHashAlgorithms.intersect(hashAlgorithms).isNotEmpty()) {
-                "Unsupported '${OpenId4VPSpec.TRANSACTION_DATA_HASH_ALGORITHMS}': '$hashAlgorithms'"
-            }
-        }
-
-        private fun TransactionData.hasCorrectIds(query: DCQL) {
-            val requestedCredentialIds = query.requestedCredentialIds()
+        private fun TransactionData.ensureCorrectCredentialIds(query: DCQL) {
+            val credentialIds = this.credentialIds
+            val requestedCredentialIds = query.credentials.ids.map { TransactionDataCredentialId(it.value) }
             require(requestedCredentialIds.containsAll(credentialIds)) {
-                "Invalid '${OpenId4VPSpec.TRANSACTION_DATA_CREDENTIAL_IDS}': '$credentialIds'"
+                "Invalid Transaction Data '${OpenId4VPSpec.TRANSACTION_DATA_CREDENTIAL_IDS}': '$credentialIds'"
             }
         }
 
-        private fun DCQL.requestedCredentialIds(): List<TransactionDataCredentialId> =
-            credentials.ids.map { TransactionDataCredentialId(it.value) }
+        fun parse(
+            value: Base64UrlSafe,
+            supportedTypes: List<SupportedTransactionDataType>,
+            query: DCQL,
+        ): Result<TransactionData> = runCatching {
+            val json = decode(value)
+            val type = json.type()
 
-        internal operator fun invoke(
+            val supportedType = supportedTypes.firstOrNull { it.type == type }
+            requireNotNull(supportedType) { "Unsupported Transaction Data '${OpenId4VPSpec.TRANSACTION_DATA_TYPE}': '$type'" }
+
+            when (supportedType) {
+                is SupportedTransactionDataType.SdJwtVc -> SdJwtVc.parse(value, supportedType, query).getOrThrow()
+            }
+        }
+
+        operator fun invoke(
             type: TransactionDataType,
             credentialIds: List<TransactionDataCredentialId>,
             hashAlgorithms: List<HashAlgorithm>? = null,
             builder: JsonObjectBuilder.() -> Unit = {},
-        ): TransactionData {
-            val json = buildJsonObject {
-                put(OpenId4VPSpec.TRANSACTION_DATA_TYPE, type.value)
-                putJsonArray(OpenId4VPSpec.TRANSACTION_DATA_CREDENTIAL_IDS) {
-                    credentialIds.forEach { add(it.value) }
+        ): SdJwtVc = SdJwtVc(type, credentialIds, hashAlgorithms, builder)
+    }
+
+    /**
+     * Represents resolved (i.e., supported by the Wallet) SD-JWT VC Transaction Data.
+     *
+     * @property hashAlgorithms Hash Algorithms with which the Hash of this Transaction Data can be calculated
+     */
+    data class SdJwtVc private constructor(override val value: Base64UrlSafe) : TransactionData {
+        override val json: JsonObject by lazy { decode(value) }
+        override val type: TransactionDataType get() = json.type()
+        override val credentialIds: List<TransactionDataCredentialId> get() = json.credentialIds()
+        val hashAlgorithms: List<HashAlgorithm> get() = json.hashAlgorithms()
+
+        companion object {
+            private val DefaultHashAlgorithm: HashAlgorithm get() = HashAlgorithm.SHA_256
+
+            private fun JsonObject.hashAlgorithms(): List<HashAlgorithm> =
+                optionalStringArray(OpenId4VPSpec.TRANSACTION_DATA_HASH_ALGORITHMS)
+                    ?.map(::HashAlgorithm)
+                    ?: listOf(DefaultHashAlgorithm)
+
+            private fun SdJwtVc.ensureSupportedHashAlgorithms(supportedType: SupportedTransactionDataType.SdJwtVc) {
+                val hashAlgorithms = this.hashAlgorithms
+                val supportedHashAlgorithms = supportedType.hashAlgorithms
+                require(supportedHashAlgorithms.intersect(hashAlgorithms).isNotEmpty()) {
+                    "Unsupported Transaction Data '${OpenId4VPSpec.TRANSACTION_DATA_HASH_ALGORITHMS}': '$hashAlgorithms'"
                 }
-                if (!hashAlgorithms.isNullOrEmpty()) {
-                    putJsonArray(OpenId4VPSpec.TRANSACTION_DATA_HASH_ALGORITHMS) {
-                        hashAlgorithms.forEach { add(it.name) }
+            }
+
+            fun parse(
+                value: Base64UrlSafe,
+                supportedType: SupportedTransactionDataType.SdJwtVc,
+                query: DCQL,
+            ): Result<SdJwtVc> = runCatching {
+                SdJwtVc(value)
+                    .also {
+                        it.ensureSupportedType(supportedType.type)
+                        it.ensureCorrectCredentialIds(query)
+                        it.ensureSupportedHashAlgorithms(supportedType)
+                    }
+            }
+
+            operator fun invoke(
+                type: TransactionDataType,
+                credentialIds: List<TransactionDataCredentialId>,
+                hashAlgorithms: List<HashAlgorithm>? = null,
+                builder: JsonObjectBuilder.() -> Unit = {},
+            ): SdJwtVc {
+                val json = buildJsonObject {
+                    builder()
+
+                    put(OpenId4VPSpec.TRANSACTION_DATA_TYPE, type.value)
+                    putJsonArray(OpenId4VPSpec.TRANSACTION_DATA_CREDENTIAL_IDS) {
+                        credentialIds.forEach { add(it.value) }
+                    }
+                    if (!hashAlgorithms.isNullOrEmpty()) {
+                        putJsonArray(OpenId4VPSpec.TRANSACTION_DATA_HASH_ALGORITHMS) {
+                            hashAlgorithms.forEach { add(it.name) }
+                        }
                     }
                 }
-                builder()
-            }
-            val serialized = jsonSupport.encodeToString(json)
-            val base64 = base64UrlNoPadding.encode(serialized.encodeToByteArray())
-            return TransactionData(base64)
-        }
 
-        internal operator fun invoke(
-            s: String,
-            supportedTypes: List<SupportedTransactionDataType>,
-            query: DCQL,
-        ): Result<TransactionData> = runCatching {
-            parse(s).getOrThrow().also {
-                it.isSupported(supportedTypes)
-                it.hasCorrectIds(query)
+                val serialized = jsonSupport.encodeToString(json)
+                val base64 = base64UrlNoPadding.encode(serialized.encodeToByteArray())
+
+                return SdJwtVc(base64)
             }
         }
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
@@ -148,7 +148,7 @@ sealed interface TransactionData : java.io.Serializable {
             }
         }
 
-        operator fun invoke(
+        fun sdJwtVc(
             type: TransactionDataType,
             credentialIds: List<QueryId>,
             hashAlgorithms: List<HashAlgorithm>? = null,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -25,7 +25,6 @@ import com.nimbusds.oauth2.sdk.id.Issuer
 import eu.europa.ec.eudi.openid4vp.ResponseEncryptionConfiguration.NotSupported
 import eu.europa.ec.eudi.openid4vp.SiopOpenId4VPConfig.Companion.SelfIssued
 import eu.europa.ec.eudi.openid4vp.dcql.DCQL
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 import java.net.URI
 import java.security.PublicKey
@@ -147,13 +146,17 @@ sealed interface SupportedClientIdPrefix {
 /**
  * A type of Transaction Data supported by the Wallet.
  */
-data class SupportedTransactionDataType(
-    val type: TransactionDataType,
-    val hashAlgorithms: Set<HashAlgorithm>,
-) {
-    init {
-        require(hashAlgorithms.isNotEmpty()) { "hashAlgorithms cannot be empty" }
-        require(HashAlgorithm.SHA_256 in hashAlgorithms) { "'${HashAlgorithm.SHA_256.name}' must be a supported hash algorithm" }
+sealed interface SupportedTransactionDataType {
+    val type: TransactionDataType
+
+    data class SdJwtVc(
+        override val type: TransactionDataType,
+        val hashAlgorithms: Set<HashAlgorithm>,
+    ) : SupportedTransactionDataType {
+        init {
+            require(hashAlgorithms.isNotEmpty()) { "hashAlgorithms cannot be empty" }
+            require(HashAlgorithm.SHA_256 in hashAlgorithms) { "'${HashAlgorithm.SHA_256.name}' must be a supported hash algorithm" }
+        }
     }
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -171,7 +171,15 @@ data class VPConfiguration(
     val knownDCQLQueriesPerScope: Map<String, DCQL> = emptyMap(),
     val vpFormatsSupported: VpFormatsSupported,
     val supportedTransactionDataTypes: List<SupportedTransactionDataType> = emptyList(),
-)
+) {
+    init {
+        if (null == vpFormatsSupported.sdJwtVc) {
+            require(supportedTransactionDataTypes.none { it is SupportedTransactionDataType.SdJwtVc }) {
+                "SD-JWT VC Transaction Data cannot be used when SD-JWT VC is not supported"
+            }
+        }
+    }
+}
 
 /**
  * Configurations options for encrypting an authorization response if requested by the verifier.

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Types.kt
@@ -310,15 +310,6 @@ value class TransactionDataType(val value: String) : java.io.Serializable {
 }
 
 @JvmInline
-value class TransactionDataCredentialId(val value: String) : java.io.Serializable {
-    init {
-        require(value.isNotEmpty())
-    }
-
-    override fun toString(): String = value
-}
-
-@JvmInline
 @Serializable
 value class CoseAlgorithm(val value: Int) : java.io.Serializable {
     override fun toString(): String = value.toString()

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectValidator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectValidator.kt
@@ -169,7 +169,7 @@ internal class RequestObjectValidator(private val siopOpenId4VPConfig: SiopOpenI
         requestObject.transactionData?.let { unresolvedTransactionData ->
             runCatching {
                 unresolvedTransactionData.values.map { unresolved ->
-                    TransactionData(
+                    TransactionData.parse(
                         unresolved,
                         siopOpenId4VPConfig.vpConfiguration.supportedTransactionDataTypes,
                         query,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectValidator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectValidator.kt
@@ -169,11 +169,9 @@ internal class RequestObjectValidator(private val siopOpenId4VPConfig: SiopOpenI
         requestObject.transactionData?.let { unresolvedTransactionData ->
             runCatching {
                 unresolvedTransactionData.values.map { unresolved ->
-                    TransactionData.parse(
-                        unresolved,
-                        siopOpenId4VPConfig.vpConfiguration.supportedTransactionDataTypes,
-                        query,
-                    ).getOrThrow()
+                    val transactionData = TransactionData.parse(unresolved, query).getOrThrow()
+                    transactionData.ensureSupported(siopOpenId4VPConfig.vpConfiguration.supportedTransactionDataTypes)
+                    transactionData
                 }
             }.getOrElse { error -> throw ResolutionError.InvalidTransactionData(error).asException() }
         }
@@ -393,4 +391,24 @@ private enum class ResponseType {
     VpToken,
     IdToken,
     VpAndIdToken,
+}
+
+private fun TransactionData.ensureSupported(supportedTransactionDataTypes: List<SupportedTransactionDataType>) =
+    when (this) {
+        is TransactionData.SdJwtVc -> ensureSupported(supportedTransactionDataTypes)
+    }
+
+private fun TransactionData.SdJwtVc.ensureSupported(supportedTransactionDataTypes: List<SupportedTransactionDataType>) {
+    val type = this.type
+
+    val supportedType = supportedTransactionDataTypes.firstOrNull { it.type == type }
+    require(supportedType is SupportedTransactionDataType.SdJwtVc) {
+        "Unsupported Transaction Data '${OpenId4VPSpec.TRANSACTION_DATA_TYPE}': '$type'"
+    }
+
+    val hashAlgorithms = this.hashAlgorithmsOrDefault
+    val supportedHashAlgorithms = supportedType.hashAlgorithms
+    require(supportedHashAlgorithms.intersect(hashAlgorithms).isNotEmpty()) {
+        "Unsupported Transaction Data '${OpenId4VPSpec.TRANSACTION_DATA_HASH_ALGORITHMS}': '$hashAlgorithms'"
+    }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
@@ -418,7 +418,7 @@ private class Wallet(
                 .claim("sd_hash", sdHash)
                 .apply {
                     if (!transactionData.isNullOrEmpty()) {
-                        check(transactionData.all { HashAlgorithm.SHA_256 in it.hashAlgorithms })
+                        check(transactionData.all { it is TransactionData.SdJwtVc && HashAlgorithm.SHA_256 in it.hashAlgorithms })
 
                         val transactionDataHashes = transactionData.map {
                             val digest = MessageDigest.getInstance("SHA-256")
@@ -457,7 +457,7 @@ private fun walletConfig(vararg supportedClientIdPrefix: SupportedClientIdPrefix
                 ),
             ),
             supportedTransactionDataTypes = listOf(
-                SupportedTransactionDataType(
+                SupportedTransactionDataType.SdJwtVc(
                     TransactionDataType("eu.europa.ec.eudi.family-name-presentation"),
                     setOf(HashAlgorithm.SHA_256),
                 ),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
@@ -274,7 +274,7 @@ sealed interface Transaction {
         val SdJwtVcPidDcql = run {
             val dcql = jsonSupport.decodeFromString<DCQLQuery>(loadResource("/example/sd-jwt-vc-pid-dcql-query.json"))
             val queryId = dcql.credentials.ids.first()
-            val transactionData = TransactionData(
+            val transactionData = TransactionData.sdJwtVc(
                 TransactionDataType("eu.europa.ec.eudi.family-name-presentation"),
                 listOf(queryId),
             ) {

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
@@ -418,7 +418,7 @@ private class Wallet(
                 .claim("sd_hash", sdHash)
                 .apply {
                     if (!transactionData.isNullOrEmpty()) {
-                        check(transactionData.all { it is TransactionData.SdJwtVc && HashAlgorithm.SHA_256 in it.hashAlgorithms })
+                        check(transactionData.all { it is TransactionData.SdJwtVc && HashAlgorithm.SHA_256 in it.hashAlgorithmsOrDefault })
 
                         val transactionDataHashes = transactionData.map {
                             val digest = MessageDigest.getInstance("SHA-256")

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
@@ -276,7 +276,7 @@ sealed interface Transaction {
             val queryId = dcql.credentials.ids.first()
             val transactionData = TransactionData(
                 TransactionDataType("eu.europa.ec.eudi.family-name-presentation"),
-                listOf(TransactionDataCredentialId(queryId.value)),
+                listOf(queryId),
             ) {
                 put("purpose", "We must verify your Family Name")
             }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
@@ -860,7 +860,7 @@ class UnvalidatedRequestResolverTest {
 
         @Test
         fun `if transaction_data contains unsupported type, resolution fails`() = runTest {
-            val transactionData = TransactionData(
+            val transactionData = TransactionData.sdJwtVc(
                 TransactionDataType("unsupported"),
                 listOf(QueryId("foo")),
             )
@@ -910,7 +910,7 @@ class UnvalidatedRequestResolverTest {
         @Test
         fun `if transaction_data contains credential_ids that don't match inputdescriptor ids, resolution fails`() =
             runTest {
-                val transactionData = TransactionData(
+                val transactionData = TransactionData.sdJwtVc(
                     TransactionDataType("basic-transaction-data"),
                     listOf(QueryId("invalid-id")),
                 )
@@ -926,7 +926,7 @@ class UnvalidatedRequestResolverTest {
 
         @Test
         fun `if transaction_data contains credential_ids that don't match query ids, resolution fails`() = runTest {
-            val transactionData = TransactionData(
+            val transactionData = TransactionData.sdJwtVc(
                 TransactionDataType("basic-transaction-data"),
                 listOf(QueryId("invalid-id")),
             )
@@ -982,7 +982,7 @@ class UnvalidatedRequestResolverTest {
 
         @Test
         fun `if transaction_data contains unsupported transaction_data_hashes_alg, resolution fails`() = runTest {
-            val transactionData = TransactionData(
+            val transactionData = TransactionData.sdJwtVc(
                 TransactionDataType("basic-transaction-data"),
                 listOf(QueryId("my_credential")),
                 listOf(HashAlgorithm("sha-512")),
@@ -999,7 +999,7 @@ class UnvalidatedRequestResolverTest {
 
         @Test
         fun `if transaction_data is valid, when using dcql, resolution succeeds`() = runTest {
-            val transactionData = TransactionData(
+            val transactionData = TransactionData.sdJwtVc(
                 TransactionDataType("basic-transaction-data"),
                 listOf(QueryId("my_credential")),
                 listOf(HashAlgorithm.SHA_256),
@@ -1022,7 +1022,7 @@ class UnvalidatedRequestResolverTest {
 
         @Test
         fun `if transaction_data is valid, resolution succeeds`() = runTest {
-            val transactionData = TransactionData(
+            val transactionData = TransactionData.sdJwtVc(
                 TransactionDataType("basic-transaction-data"),
                 listOf(QueryId("my_credential")),
                 listOf(HashAlgorithm.SHA_256),
@@ -1046,7 +1046,7 @@ class UnvalidatedRequestResolverTest {
         @Test
         fun `if transaction_data is valid, and contains no transaction_data_hashes_alg, resolution succeeds`() =
             runTest {
-                val transactionData = TransactionData(
+                val transactionData = TransactionData.sdJwtVc(
                     TransactionDataType("basic-transaction-data"),
                     listOf(QueryId("my_credential")),
                 )
@@ -1069,7 +1069,7 @@ class UnvalidatedRequestResolverTest {
         @Test
         fun `if transaction_data is valid, and contains transaction_data_hashes_alg without sha-256, resolution succeeds`() =
             runTest {
-                val transactionData = TransactionData(
+                val transactionData = TransactionData.sdJwtVc(
                     TransactionDataType("basic-transaction-data"),
                     listOf(QueryId(("my_credential"))),
                     listOf(HashAlgorithm("sha-384")),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
@@ -862,7 +862,7 @@ class UnvalidatedRequestResolverTest {
         fun `if transaction_data contains unsupported type, resolution fails`() = runTest {
             val transactionData = TransactionData.sdJwtVc(
                 TransactionDataType("unsupported"),
-                listOf(QueryId("foo")),
+                listOf(QueryId("my_credential")),
             )
             testAndThen(transactionData.json) {
                 val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
@@ -30,6 +30,7 @@ import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.oauth2.sdk.id.State
 import eu.europa.ec.eudi.openid4vp.dcql.DCQL
+import eu.europa.ec.eudi.openid4vp.dcql.QueryId
 import eu.europa.ec.eudi.openid4vp.internal.base64UrlNoPadding
 import eu.europa.ec.eudi.openid4vp.internal.jsonSupport
 import eu.europa.ec.eudi.openid4vp.internal.request.DefaultAuthorizationRequestResolver
@@ -861,7 +862,7 @@ class UnvalidatedRequestResolverTest {
         fun `if transaction_data contains unsupported type, resolution fails`() = runTest {
             val transactionData = TransactionData(
                 TransactionDataType("unsupported"),
-                listOf(TransactionDataCredentialId("foo")),
+                listOf(QueryId("foo")),
             )
             testAndThen(transactionData.json) {
                 val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
@@ -911,7 +912,7 @@ class UnvalidatedRequestResolverTest {
             runTest {
                 val transactionData = TransactionData(
                     TransactionDataType("basic-transaction-data"),
-                    listOf(TransactionDataCredentialId("invalid-id")),
+                    listOf(QueryId("invalid-id")),
                 )
                 testAndThen(transactionData.json) {
                     val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
@@ -927,7 +928,7 @@ class UnvalidatedRequestResolverTest {
         fun `if transaction_data contains credential_ids that don't match query ids, resolution fails`() = runTest {
             val transactionData = TransactionData(
                 TransactionDataType("basic-transaction-data"),
-                listOf(TransactionDataCredentialId("invalid-id")),
+                listOf(QueryId("invalid-id")),
             )
             testAndThen(transactionData.json, dcqlQuery) {
                 val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
@@ -983,7 +984,7 @@ class UnvalidatedRequestResolverTest {
         fun `if transaction_data contains unsupported transaction_data_hashes_alg, resolution fails`() = runTest {
             val transactionData = TransactionData(
                 TransactionDataType("basic-transaction-data"),
-                listOf(TransactionDataCredentialId("my_credential")),
+                listOf(QueryId("my_credential")),
                 listOf(HashAlgorithm("sha-512")),
             )
             testAndThen(transactionData.json, dcqlQuery) {
@@ -1000,7 +1001,7 @@ class UnvalidatedRequestResolverTest {
         fun `if transaction_data is valid, when using dcql, resolution succeeds`() = runTest {
             val transactionData = TransactionData(
                 TransactionDataType("basic-transaction-data"),
-                listOf(TransactionDataCredentialId("my_credential")),
+                listOf(QueryId("my_credential")),
                 listOf(HashAlgorithm.SHA_256),
             )
             testAndThen(transactionData.json, dcqlQuery) {
@@ -1012,7 +1013,7 @@ class UnvalidatedRequestResolverTest {
                 }
                 assertEquals(TransactionDataType("basic-transaction-data"), resolvedTransactionData.type)
                 assertEquals(
-                    listOf(TransactionDataCredentialId("my_credential")),
+                    listOf(QueryId("my_credential")),
                     resolvedTransactionData.credentialIds,
                 )
                 assertEquals(listOf(HashAlgorithm.SHA_256), resolvedTransactionData.hashAlgorithms)
@@ -1023,7 +1024,7 @@ class UnvalidatedRequestResolverTest {
         fun `if transaction_data is valid, resolution succeeds`() = runTest {
             val transactionData = TransactionData(
                 TransactionDataType("basic-transaction-data"),
-                listOf(TransactionDataCredentialId("my_credential")),
+                listOf(QueryId("my_credential")),
                 listOf(HashAlgorithm.SHA_256),
             )
             testAndThen(transactionData.json) {
@@ -1035,7 +1036,7 @@ class UnvalidatedRequestResolverTest {
                 }
                 assertEquals(TransactionDataType("basic-transaction-data"), resolvedTransactionData.type)
                 assertEquals(
-                    listOf(TransactionDataCredentialId("my_credential")),
+                    listOf(QueryId("my_credential")),
                     resolvedTransactionData.credentialIds,
                 )
                 assertEquals(listOf(HashAlgorithm.SHA_256), resolvedTransactionData.hashAlgorithms)
@@ -1047,7 +1048,7 @@ class UnvalidatedRequestResolverTest {
             runTest {
                 val transactionData = TransactionData(
                     TransactionDataType("basic-transaction-data"),
-                    listOf(TransactionDataCredentialId("my_credential")),
+                    listOf(QueryId("my_credential")),
                 )
                 testAndThen(transactionData.json) {
                     val request = it.validateSuccess<ResolvedRequestObject.OpenId4VPAuthorization>()
@@ -1058,7 +1059,7 @@ class UnvalidatedRequestResolverTest {
                     }
                     assertEquals(TransactionDataType("basic-transaction-data"), resolvedTransactionData.type)
                     assertEquals(
-                        listOf(TransactionDataCredentialId("my_credential")),
+                        listOf(QueryId("my_credential")),
                         resolvedTransactionData.credentialIds,
                     )
                     assertEquals(listOf(HashAlgorithm.SHA_256), resolvedTransactionData.hashAlgorithmsOrDefault)
@@ -1070,7 +1071,7 @@ class UnvalidatedRequestResolverTest {
             runTest {
                 val transactionData = TransactionData(
                     TransactionDataType("basic-transaction-data"),
-                    listOf(TransactionDataCredentialId(("my_credential"))),
+                    listOf(QueryId(("my_credential"))),
                     listOf(HashAlgorithm("sha-384")),
                 )
                 testAndThen(transactionData.json) {
@@ -1082,7 +1083,7 @@ class UnvalidatedRequestResolverTest {
                     }
                     assertEquals(TransactionDataType("basic-transaction-data"), resolvedTransactionData.type)
                     assertEquals(
-                        listOf(TransactionDataCredentialId("my_credential")),
+                        listOf(QueryId("my_credential")),
                         resolvedTransactionData.credentialIds,
                     )
                     assertEquals(listOf(HashAlgorithm("sha-384")), resolvedTransactionData.hashAlgorithms)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
@@ -1061,7 +1061,7 @@ class UnvalidatedRequestResolverTest {
                         listOf(TransactionDataCredentialId("my_credential")),
                         resolvedTransactionData.credentialIds,
                     )
-                    assertEquals(listOf(HashAlgorithm.SHA_256), resolvedTransactionData.hashAlgorithms)
+                    assertEquals(listOf(HashAlgorithm.SHA_256), resolvedTransactionData.hashAlgorithmsOrDefault)
                 }
             }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
@@ -161,7 +161,7 @@ class UnvalidatedRequestResolverTest {
                 ),
             ),
             supportedTransactionDataTypes = listOf(
-                SupportedTransactionDataType(
+                SupportedTransactionDataType.SdJwtVc(
                     TransactionDataType("basic-transaction-data"),
                     setOf(HashAlgorithm.SHA_256, HashAlgorithm("sha-384")),
                 ),
@@ -867,7 +867,7 @@ class UnvalidatedRequestResolverTest {
                 val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
                 val cause = assertIs<IllegalArgumentException>(error.cause)
                 assertEquals(
-                    "Unsupported transaction_data 'type': 'unsupported'",
+                    "Unsupported Transaction Data 'type': 'unsupported'",
                     cause.message,
                 )
             }
@@ -917,7 +917,7 @@ class UnvalidatedRequestResolverTest {
                     val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
                     val cause = assertIs<IllegalArgumentException>(error.cause)
                     assertEquals(
-                        "Invalid 'credential_ids': '[invalid-id]'",
+                        "Invalid Transaction Data 'credential_ids': '[invalid-id]'",
                         cause.message,
                     )
                 }
@@ -933,7 +933,7 @@ class UnvalidatedRequestResolverTest {
                 val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
                 val cause = assertIs<IllegalArgumentException>(error.cause)
                 assertEquals(
-                    "Invalid 'credential_ids': '[invalid-id]'",
+                    "Invalid Transaction Data 'credential_ids': '[invalid-id]'",
                     cause.message,
                 )
             }
@@ -990,7 +990,7 @@ class UnvalidatedRequestResolverTest {
                 val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
                 val cause = assertIs<IllegalArgumentException>(error.cause)
                 assertEquals(
-                    "Unsupported 'transaction_data_hashes_alg': '[sha-512]'",
+                    "Unsupported Transaction Data 'transaction_data_hashes_alg': '[sha-512]'",
                     cause.message,
                 )
             }
@@ -1008,7 +1008,7 @@ class UnvalidatedRequestResolverTest {
                 val resolvedTransactionData = run {
                     val resolvedTransactionData = assertNotNull(request.transactionData)
                     assertEquals(1, resolvedTransactionData.size)
-                    resolvedTransactionData.first()
+                    assertIs<TransactionData.SdJwtVc>(resolvedTransactionData.first())
                 }
                 assertEquals(TransactionDataType("basic-transaction-data"), resolvedTransactionData.type)
                 assertEquals(
@@ -1031,7 +1031,7 @@ class UnvalidatedRequestResolverTest {
                 val resolvedTransactionData = run {
                     val resolvedTransactionData = assertNotNull(request.transactionData)
                     assertEquals(1, resolvedTransactionData.size)
-                    resolvedTransactionData.first()
+                    assertIs<TransactionData.SdJwtVc>(resolvedTransactionData.first())
                 }
                 assertEquals(TransactionDataType("basic-transaction-data"), resolvedTransactionData.type)
                 assertEquals(
@@ -1054,7 +1054,7 @@ class UnvalidatedRequestResolverTest {
                     val resolvedTransactionData = run {
                         val resolvedTransactionData = assertNotNull(request.transactionData)
                         assertEquals(1, resolvedTransactionData.size)
-                        resolvedTransactionData.first()
+                        assertIs<TransactionData.SdJwtVc>(resolvedTransactionData.first())
                     }
                     assertEquals(TransactionDataType("basic-transaction-data"), resolvedTransactionData.type)
                     assertEquals(
@@ -1078,7 +1078,7 @@ class UnvalidatedRequestResolverTest {
                     val resolvedTransactionData = run {
                         val resolvedTransactionData = assertNotNull(request.transactionData)
                         assertEquals(1, resolvedTransactionData.size)
-                        resolvedTransactionData.first()
+                        assertIs<TransactionData.SdJwtVc>(resolvedTransactionData.first())
                     }
                     assertEquals(TransactionDataType("basic-transaction-data"), resolvedTransactionData.type)
                     assertEquals(

--- a/src/test/resources/dcql/complex_example.json
+++ b/src/test/resources/dcql/complex_example.json
@@ -1,0 +1,28 @@
+{
+  "credentials": [
+    {
+      "id": "my_credential_1",
+      "format": "dc+sd-jwt",
+      "meta": {
+        "vct_values": [ "https://credentials.example.com/identity_credential" ]
+      },
+      "claims": [
+        {"path": ["last_name"]},
+        {"path": ["first_name"]},
+        {"path": ["address", "street_address"]}
+      ]
+    },
+    {
+      "id": "my_credential_2",
+      "format": "mso_mdoc",
+      "meta": {
+        "vct_values": [ "https://credentials.example.com/driving_license_credential" ]
+      },
+      "claims": [
+        {"path": ["credentials.example.com", "lastName"]},
+        {"path": ["credentials.example.com","firstName"]},
+        {"path": ["credentials.example.com", "address"]}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR:

1. Converts `TransactionData` to a sealed interface. Top level properties are: `value` (the original Base64 Url-Safe encoded value), `json` (the decoded `JsonObject`), `type` (the Type of Transaction Data), and `credentialIds` (list of DCQL Query Ids this Transaction Data is applicable to)
2. Introduces `TransactionData.SdJwtVc` implementation of `TransactionData`. Extra properties: `hashAlgorithms` (Verifier-supported Hash Algorithms with which the hash of the original Base64 Url-Safe value must be calculated with)
3. Converts `SupportedTransactionDataType` to a a sealed hierarchy. Top level properties: `type` (the Type of the supported Transaction Data)
4. Introduces `SupportedTransactionDataType.SdJwtVc` implementation of `SupportedTransactionDataType`. Extra top level properties: `hashAlgorithms` (Wallet-supported Hash Algorithm swith which the hash of the original Base64 Url-Safe value can be calculated with)

Unfortunately a polymorphic deserializer cannot be introduced. Unfortunately Transaction Data do not contain profile specific required properties that could be used to distinguish them. For instance in SD-JWT VC Transaction Data `transaction_data_hashes_alg` is an optional property.

Closes #398 