### PR TITLE
feat: relax MsoMdoc ClaimPath validation to support deeper paths

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/dcql/DCQL.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/dcql/DCQL.kt
@@ -469,11 +469,11 @@ data class ClaimsQuery(
         ): ClaimsQuery = mdoc(id, ClaimPath.claim(namespace).claim(claimName), values, intentToRetain)
 
         fun ensureMsoMdoc(claimsQuery: ClaimsQuery) {
-            require(2 == claimsQuery.path.value.size) {
-                "ClaimPaths for MSO MDoc based formats must have exactly two elements"
+            require(claimsQuery.path.value.size >= 2) {
+                "ClaimPaths for MSO MDoc based formats must have at least two elements (namespace and element identifier)"
             }
-            require(claimsQuery.path.value.all { it is ClaimPathElement.Claim }) {
-                "ClaimPaths for MSO MDoc based formats must contain only Claim ClaimPathElements"
+            require(claimsQuery.path.value.take(2).all { it is ClaimPathElement.Claim }) {
+                "The first two elements of an MSO MDoc ClaimPath (namespace and element identifier) must be Claim elements"
             }
         }
 


### PR DESCRIPTION
## Summary
  - Relaxed `ensureMsoMdoc` validation to allow MsoMdoc DCQL claim paths with more than 2 elements
  - The first two elements (namespace + elementIdentifier) must still be `Claim` type
  - Additional path elements (e.g., `AllArrayElements`, `ArrayElement`) are now permitted for navigating into claim values

  ## Motivation
  DCQL queries like `{path: ["namespace", "nationality", null], values: ["LU", "FR"]}` need to traverse into array-typed MsoMdoc claim values. The previous validation rejected any path
   with more than exactly 2 elements, making array element matching impossible.

  ## Changes
  - `ensureMsoMdoc()` in `DCQL.kt`:
    - `require(2 == size)` → `require(size >= 2)`
    - `require(all { it is Claim })` → `require(take(2).all { it is Claim })`