### PR TITLE
DC-API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@ the [EUDI Wallet Reference Implementation project description](https://github.co
 * [Overview](#overview)
 * [Disclaimer](#disclaimer)
 * [How to use](#how-to-use)
-  * [Resolve an authorization request URI](#resolve-an-authorization-request-uri)
-  * [Holder's consensus, Handling of a valid authorization request](#holders-consensus-handling-of-a-valid-authorization-request)
-  * [Dispatch authorization response to verifier / RP](#dispatch-authorization-response-to-verifier--rp)
-  * [Dispatch authorization error response to verifier / RP](#dispatch-authorization-error-response-to-verifier--rp)
-  * [Example](#example)
+    * [Openid4VP via http](#openid4vp-via-http-redirects)
+      * [Resolve an authorization request URI](#resolve-an-authorization-request-uri)
+      * [Holder's consensus, Handling of a valid authorization request](#holders-consensus-handling-of-a-valid-authorization-request)
+      * [Dispatch authorization response to verifier / RP](#dispatch-authorization-response-to-verifier--rp)
+      * [Dispatch authorization error response to verifier / RP](#dispatch-authorization-error-response-to-verifier--rp)
+    * [Openid4VP via DC-API](#openid4vp-via-dc-api)
+      * [Resolve an authorization request](#resolve-an-authorization-request)
+      * [Assemble an authorization response](#assemble-an-authorization-response)
+    * [Example](#example)
 * [OpenId4VP features supported](#openid4vp-features-supported)
 * [How to contribute](#how-to-contribute)
 * [License](#license)
@@ -36,10 +40,10 @@ In particular, the library focuses on the wallet's role using this protocol, and
 | [Dispatch positive and negative responses](#dispatch-authorization-response-to-verifier--rp)                              | ✅                                                                                                                                      |
 | [Dispatch authorization error response to verifier when possible](#dispatch-authorization-error-response-to-verifier--rp) | ✅                                                                                                                                      |
 | Encrypted authorization responses                                                                                         | ✅                                                                                                                                      |
-| Response modes                                                                                                            | ✅ direct_post, ✅ direct_post.jwt, ✅ query, ✅ query.jwt, ✅ fragment, ✅ fragment.jwt                                                     |
+| Response modes                                                                                                            | ✅ direct_post, ✅ direct_post.jwt, ✅ query, ✅ query.jwt, ✅ fragment, ✅ fragment.jwt, ✅ dc_api, ✅ dc_api.jwt                             |
 | Transaction Data                                                                                                          | ✅                                                                                                                                      |
 | Verifier Attestation JWT                                                                                                  | ✅                                                                                                                                      |
-| Digital Credential API                                                                                                    | ❌                                                                                                                                      |
+| Digital Credential API                                                                                                    | ✅                                                                                                                                      |
 
 ## Disclaimer
 
@@ -77,11 +81,15 @@ dependencies {
 }
 ```
 
-The entry point to the library is the interface [OpenId4Vp](src/main/kotlin/eu/europa/ec/eudi/openid4vp/OpenId4Vp.kt)
-Currently, the library offers an implementation of this interface based on [Ktor](https://ktor.io/) Http Client.
+The library distinguishes 2 channels via which an authorization request can be received
+- Via http (redirects) 
+- Via [DC-API](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#appendix-A)
+
+The entry point to the library is the interface [OpenId4Vp](src/main/kotlin/eu/europa/ec/eudi/openid4vp/OpenId4Vp.kt).
+Currently, the library offers two implementations of this interface based on [Ktor](https://ktor.io/) Http Client.
 Ktor is built from the ground up using Kotlin and Coroutines.
 
-An instance of the interface can be obtained with the following code
+Depending on the channel via which the request is received, an instance of the interface can be obtained with the following code
 
 ```kotlin
 import eu.europa.ec.eudi.openid4vp.*
@@ -95,10 +103,16 @@ val httpClient = HttpClient {
   expectSuccess = true
 }
 
-val openId4Vp = OpenId4Vp(walletConfig, httpClient)
+// To handle requests coming through the http channel
+val openId4VpOverHttp = OpenId4Vp.overRedirects(walletConfig, httpClient)
+
+// To handle requests coming through the DC-API channel
+val openId4VpOverDcApi = OpenId4Vp.overDcApi(walletConfig, httpClient)
 ```
 
-### Resolve an authorization request URI
+### Openid4VP via http (redirects)
+
+#### Resolve an authorization request URI
 
 Wallet receives an OAuth2.0 Authorization request, formed by the Verifier, that represents an
 [OpenID4VP authorization request](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-authorization-request).
@@ -112,21 +126,23 @@ requests mentioned aforementioned) and in addition gather from Verifier addition
 reference (such as `request_uri` etc.)
 
 The interface that captures the aforementioned functionality is
-[AuthorizationRequestResolver](src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt)
+[AuthorizationRequestOverHttpResolver](src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt)
 
 ```kotlin
 import eu.europa.ec.eudi.openid4vp.*
 
 val authorizationRequestUri : String // obtained via a deep link or scanning a QR code
 
-val resolution = openId4Vp.resolveRequestUri(authorizationRequestUri)
+val openId4VpOverHttp = OpenId4Vp.overRedirects(walletConfig, httpClient)
+
+val resolution = openId4VpOverHttp.resolveRequestUri(authorizationRequestUri)
 val requestObject = when (resolution) {
     is Resolution.Invalid -> throw resolution.error.asException()
     is Resolution.Success -> resolution.requestObject
 }
-
 ```
-### Holder's consensus, Handling of a valid authorization request
+
+#### Holder's consensus, handling of a valid authorization request
 
 After receiving a valid authorization, the wallet has to process it. This means:
 
@@ -135,7 +151,7 @@ After receiving a valid authorization, the wallet has to process it. This means:
 
 This functionality is a wallet concern, and it is not supported directly by the library
 
-### Dispatch authorization response to verifier / RP
+#### Dispatch authorization response to verifier / RP
 
 After collecting holder's consensus, wallet can use the library to form an appropriate response and then dispatch it
 to the verifier.
@@ -153,13 +169,16 @@ just forms an appropriate redirect URI.
 It is the caller's responsibility to redirect the user to this URI.
 
 ```kotlin
+val openId4VpOverHttp = OpenId4Vp.overRedirects(walletConfig, httpClient)
+
 val requestObject // calculated in previous step
 val verifiablePresentations: VerifiablePresentations // provided by wallet
 val consensus =  Consensus.PositiveConsensus(verifiablePresentations)
-val dispatchOutcome = openId4Vp.dispatch(requestObject, consensus)
+
+val dispatchOutcome = openId4VpOverHttp.dispatch(requestObject, consensus)
 ```
 
-### Dispatch authorization error response to verifier / RP
+#### Dispatch authorization error response to verifier / RP
 
 If an error occurs during the resolution of an authorization request URI, either due to the authorization request
 missing required data or being malformed, a Resolution.Invalid is returned. Depending on the type of the
@@ -189,14 +208,16 @@ It is the caller's responsibility to redirect the user to this URI.
 ```kotlin
 import eu.europa.ec.eudi.openid4vp.*
 
+val openId4VpOverHttp = OpenId4Vp.overRedirects(walletConfig, httpClient)
+
 val authorizationRequestUri : String // obtained via a deep link or scanning a QR code
 
-val resolution = openId4Vp.resolveRequestUri(authorizationRequestUri)
+val resolution = openId4VpOverHttp.resolveRequestUri(authorizationRequestUri)
 if (resolution is Resolution.Invalid) {
   val (error, errorDispatchDetails) = resolution.error
   errorDispatchDetails?.let {
     val encryptionParameters: EncryptionParameters = TODO()
-    val dispatchOutcome = openId4Vp.dispatchError(error, it, encryptionParameters)
+    val dispatchOutcome = openId4VpOverHttp.dispatchError(error, it, encryptionParameters)
     when (dispatchOutcome) {
       is DispatchOutcome.RedirectURI -> TODO("Caller must redirect the user to '${dispatchOutcome.value}'")
       is DispatchOutcome.VerifierResponse.Accepted -> TODO("Verifier/RP successfully received authorization error response. Caller must redirect user to '${dispatchOutcome.redirectURI}'")
@@ -206,11 +227,118 @@ if (resolution is Resolution.Invalid) {
 }
 ```
 
+### Openid4VP via DC-API
+
+The diagram below illustrates the interaction of a `Verifier` and a `Wallet` via Verifier's trusted end-point (trusted origin) to perform an OpenId4VP Authorization via DC-API.
+User's agent might also be a mobile app installed in user's device. 
+In both cases the operating system guarantees that the origin of the request (web domain or app package name) cannot be spoofed.
+
+Given that the `Verifier` has prepared the appropriate request, and displayed to `Holder` through holder device's agent (browser) the flow below how the android OS (implements DC-API)
+the EUDI Wallet interact. Also describes the responsibilities of the current library in the process.  
+
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User as Holder (User)
+    participant Web as Verifier via user's agent<br>(Browser)
+    participant ACM as Android Credential Manager<br>(System OS)
+    participant Wallet as Wallet App<br>(CredentialHandlerActivity)
+    participant lib as OpenId4VP Library
+    
+
+    %% Step 1: Initialization
+    User->>Web: Clicks "Verify Identity"
+    Web->>ACM: navigator.credentials.get()<br>(Sends Request Payload + Origin)
+
+    %% Step 2: System Matching & Chooser
+    Note over ACM: OS validates Web Origin<br>Scans installed apps for matching document types
+    ACM->>User: Displays System Chooser UI<br>(Lists available Wallet Apps)
+    User->>ACM: Selects Your Wallet App
+
+    %% Step 3: Intent Forwarding to Wallet
+    ACM->>Wallet: Launches Activity via System Intent<br>(GET_CREDENTIAL action + Extras payload)
+    
+    %% Step 4: Wallet Internal Processing
+    Wallet->>lib: Forward received request <br/> (origin, protocol, payload)
+    lib->>lib: Validate incoming request
+    lib->>Wallet: validated request    
+    Wallet->>User: Present matched credentials and request user consent 
+    User->>Wallet: Confirms Consent & Triggers Biometrics
+    Wallet->>lib: Pass concent with selected credentials
+    lib->>lib: Prepare vp_token response <br/> (vp_token as JsonObject) 
+    lib->>Wallet: Assembled response
+    
+    %% Step 6: Returning the Data up the chain
+    Wallet->>ACM: setResult(RESULT_OK, resultIntent)<br>(Passes cryptographically signed bundle)
+    Note over Wallet: Wallet Activity finishes/closes
+    ACM->>Web: Delivers credential object to browser
+    Web->>User: Authentication Successful
+
+```
+
+#### Resolve an authorization request
+
+Wallet receives an OAuth2.0 Authorization request, formed by the Verifier, that represents an
+OpenID4VP authorization request, specifically for the case of [DC-API](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-request).
+
+The resolution the authorization request follows the same principled as with the case of requests received via the http channel (redirects).
+1. Wallet should extract from system intent: (a) the protocol, (b) caller's origin and (c) request payload
+2. Use OpenId4Vp.resolveRequestObject passing the above parameters
+3. The result will be either a `Resolution.Success` containing the validated request object or a `Resolution.Invalid` containing the error that occured during the validation. 
+
+The interface that captures the aforementioned functionality is
+[AuthorizationRequestOverDCApiResolver](src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt)
+
+```kotlin
+import eu.europa.ec.eudi.openid4vp.*
+
+val protocol: String // extracted from the request as it was passed to wallet from the system intent
+val origin: String // extracted from the request as it was passed to wallet from the system intent
+val requestData: JsonObject // extracted from the request as it was passed to wallet from the system intent
+
+val openId4VpOverDcApi = OpenId4Vp.overDcApi(walletConfig, httpClient)
+
+val resolution = openId4VpOverDcApi.resolveRequestObject(protocol, origin, requestData)
+val requestObject = when (resolution) {
+    is Resolution.Invalid -> throw resolution.error.asException()
+    is Resolution.Success -> resolution.requestObject
+}
+```
+
+#### Holder's consensus, handling of a valid authorization request
+
+After receiving a valid authorization, the wallet has to process it. This means:
+
+* wallet should check whether holder has claims that can fulfill verifier's requirements
+* let the holder choose which claims will be presented to the verifier and form a `vp_token`
+
+This functionality is a wallet concern, and it is not supported directly by the library
+
+#### Assemble an authorization response
+
+After collecting holder's consensus, wallet can use the library to form an appropriate response and then pass it to the verifier.
+
+In the case of requests coming through the DC-API channel, the library does not perform the actual dispatching of the response to the verifier
+(as in the case of the http channel).
+Instead, it merely assembles the response and passes it to the caller that is responsible for passing the response to the verifier via 
+an active DC-API channel. 
+
+```kotlin
+val openId4VpOverDcApi = OpenId4Vp.overDcApi(walletConfig, httpClient)
+
+val requestObject // calculated in previous step
+val verifiablePresentations: VerifiablePresentations // provided by wallet
+val consensus =  Consensus.PositiveConsensus(verifiablePresentations)
+
+val response: JsonObject = openId4VpOverDcApi.assembleResponse(requestObject, consensus)
+```
+
 ### Example
 
 Project contains an [example](src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt) which
 demonstrates the functionality of the library and in particular the interaction of a
-`Verifier` and a `Wallet` via Verifier's trusted end-point to perform an OpenId4VP Authorization.
+`Verifier` and a `Wallet` via Verifier's trusted end-point to perform an OpenId4VP Authorization via http.
 
 To run the example, you will need to clone [Verifier's trusted end-point](https://github.com/eu-digital-identity-wallet/eudi-srv-web-verifier-endpoint-23220-4-kt)
 and run it using
@@ -236,6 +364,8 @@ Library currently supports `response_mode`
 * `fragment.jwt`
 * `query`
 * `query.jwt`
+* `dc_api`
+* `dc_api.jwt`
 
 
 ### Supported Client ID Prefixes
@@ -252,7 +382,7 @@ Library requires the presence of a `client_id` using one of the following prefix
 > [!NOTE]
 > The Client ID Prefix is encoded as a prefix in `client_id`. Absence of such a prefix, indicates the usage of the `pre-registered` Client ID Prefix.
 
-### Retrieving Authorization Request
+### Retrieving Authorization Request (http channel case)
 
 According to OpenID4VP, when the `request_uri` parameter is included in the authorization request wallet must fetch the Authorization Request by following this URI.
 In this case there are two methods to get the request, controlled by the `request_uri_method` communicated by the verifier:
@@ -265,7 +395,7 @@ In the later case, based on the configured [SupportedRequestUriMethods](src/main
 
 Library supports both methods.
 
-### Authorization Request encoding
+### Authorization Request encoding (http channel case)
 
 OAUTH2 foresees that `AuthorizationRequest` is encoded as an HTTP GET request which contains specific HTTP parameters.
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
@@ -531,13 +531,24 @@ fun interface AuthorizationRequestOverHttpResolver {
     suspend fun resolveRequestUri(uri: String): Resolution
 }
 
+/**
+ * A functional interface for resolving and validating authorization requests received via the
+ * Digital Credential API (DC API) channel. The implementation of this interface processes the
+ * given request data and produces a [Resolution] result, indicating whether the request was successfully
+ * validated and resolved into a [ResolvedRequestObject] or failed with an associated error.
+ */
 fun interface AuthorizationRequestOverDCApiResolver {
 
     /**
-     * Tries to validate an authorization request received via the Digital Credential API channel into a [ResolvedRequestObject].
+     * Resolves and validates an authorization request received via the Digital Credential API (DC API) channel.
+     * Processes the request data and produces a [Resolution] indicating whether the operation was successful.
      *
-     * @param origin The origin of the request
-     * @param requestData The request data as a JsonObject
+     * @param protocol The protocol associated with the request, typically specifying the communication protocol or type.
+     * @param origin The origin or source of the request, used to validate the request's sender or context.
+     * @param requestData The raw request data encapsulated as a [JsonObject], which contains the payload to be processed.
+     * @return A [Resolution] representing the outcome of the resolution process:
+     *         [Resolution.Success] if the request was successfully validated and resolved,
+     *         or [Resolution.Invalid] if the resolution failed due to an error.
      */
     suspend fun resolveRequestObject(protocol: String, origin: String, requestData: JsonObject): Resolution
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/AuthorizationRequestResolver.kt
@@ -16,9 +16,6 @@
 package eu.europa.ec.eudi.openid4vp
 
 import eu.europa.ec.eudi.openid4vp.Client.*
-import eu.europa.ec.eudi.openid4vp.TransactionData.Companion.credentialIds
-import eu.europa.ec.eudi.openid4vp.TransactionData.Companion.type
-import eu.europa.ec.eudi.openid4vp.TransactionData.SdJwtVc.Companion.hashAlgorithms
 import eu.europa.ec.eudi.openid4vp.dcql.CredentialQueryIds
 import eu.europa.ec.eudi.openid4vp.dcql.DCQL
 import eu.europa.ec.eudi.openid4vp.dcql.QueryId
@@ -46,6 +43,7 @@ sealed interface Client : java.io.Serializable {
     data class VerifierAttestation(val clientId: OriginalClientId) : Client
     data class X509SanDns(val clientId: OriginalClientId, val cert: X509Certificate) : Client
     data class X509Hash(val clientId: OriginalClientId, val cert: X509Certificate) : Client
+    data class Origin(val clientId: OriginalClientId) : Client
 
     /**
      * The id of the client prefixed with the client id prefix.
@@ -58,6 +56,7 @@ sealed interface Client : java.io.Serializable {
             is VerifierAttestation -> VerifierId(ClientIdPrefix.VerifierAttestation, clientId)
             is X509SanDns -> VerifierId(ClientIdPrefix.X509SanDns, clientId)
             is X509Hash -> VerifierId(ClientIdPrefix.X509Hash, clientId)
+            is Origin -> VerifierId(ClientIdPrefix.ORIGIN, clientId)
         }
 }
 
@@ -85,6 +84,7 @@ fun Client.legalName(legalName: X509Certificate.() -> String? = X509Certificate:
         is VerifierAttestation -> null
         is X509SanDns -> cert.legalName()
         is X509Hash -> cert.legalName()
+        is Origin -> null
     }
 }
 
@@ -417,6 +417,26 @@ sealed interface RequestValidationError : AuthorizationRequestError {
     data class DIDResolutionFailed(val didUrl: String) : RequestValidationError
 
     data class InvalidVerifierInfo(val reason: String) : RequestValidationError
+
+    data object MissingExpectedOrigins : RequestValidationError {
+        @Suppress("unused")
+        private fun readResolve(): Any = MissingExpectedOrigins
+    }
+
+    data object UnexpectedOrigin : RequestValidationError {
+        @Suppress("unused")
+        private fun readResolve(): Any = UnexpectedOrigin
+    }
+
+    data object MultiSignedRequestsNotSupported : RequestValidationError {
+        @Suppress("unused")
+        private fun readResolve(): Any = MultiSignedRequestsNotSupported
+    }
+
+    data object NoMatchingClientPrefixInMultiSignedRequest : RequestValidationError {
+        @Suppress("unused")
+        private fun readResolve(): Any = NoMatchingClientPrefixInMultiSignedRequest
+    }
 }
 
 /**
@@ -431,6 +451,11 @@ sealed interface ResolutionError : AuthorizationRequestError {
         @Suppress("unused")
         private fun readResolve(): Any = ClientVpFormatsNotSupportedFromWallet
     }
+    data object UnsupportedDcApiExchangeProtocol : ResolutionError {
+        @Suppress("unused")
+        private fun readResolve(): Any = UnsupportedDcApiExchangeProtocol
+    }
+    data class DcApiExchangeProtocolNotMatchesReceivedRequest(val cause: String) : ResolutionError
 }
 
 /**
@@ -454,7 +479,7 @@ fun <T> AuthorizationRequestError.asFailure(): Result<T> =
     Result.failure(asException())
 
 /**
- * The outcome of [validating and resolving][AuthorizationRequestResolver.resolveRequestUri]
+ * The outcome of [validating and resolving][AuthorizationRequestOverHttpResolver.resolveRequestUri]
  * an authorization request.
  */
 sealed interface Resolution {
@@ -498,10 +523,21 @@ data class ErrorDispatchDetails(
  * fetches parts of the authorization request which are provided by reference)
  *
  */
-fun interface AuthorizationRequestResolver {
+fun interface AuthorizationRequestOverHttpResolver {
 
     /**
      * Tries to validate and request the provided [uri] into a [ResolvedRequestObject].
      */
     suspend fun resolveRequestUri(uri: String): Resolution
+}
+
+fun interface AuthorizationRequestOverDCApiResolver {
+
+    /**
+     * Tries to validate an authorization request received via the Digital Credential API channel into a [ResolvedRequestObject].
+     *
+     * @param origin The origin of the request
+     * @param requestData The request data as a JsonObject
+     */
+    suspend fun resolveRequestObject(protocol: String, origin: String, requestData: JsonObject): Resolution
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -328,15 +328,23 @@ sealed interface SupportedRequestUriMethods {
     }
 }
 
+sealed interface MultiSignedRequestsPolicy {
+
+    data class Expect(val clientPrefix: ClientIdPrefix) : MultiSignedRequestsPolicy
+
+    data object NotSupported : MultiSignedRequestsPolicy
+}
+
 /**
  * Options related to JWT-Secured authorization requests
  *
  * @param supportedAlgorithms the algorithms supported for the signature of the JAR
  * @param supportedRequestUriMethods which of the `request_uri_method` methods are supported
  */
-data class JarConfiguration(
+data class SignedRequestConfiguration(
     val supportedAlgorithms: List<JWSAlgorithm>,
     val supportedRequestUriMethods: SupportedRequestUriMethods = SupportedRequestUriMethods.Default,
+    val multiSignedRequestsPolicy: MultiSignedRequestsPolicy = MultiSignedRequestsPolicy.NotSupported,
 ) {
     init {
         require(supportedAlgorithms.isNotEmpty()) { "JAR signing algorithms cannot be empty" }
@@ -349,9 +357,10 @@ data class JarConfiguration(
          *
          * @see SupportedRequestUriMethods.Default
          */
-        val Default = JarConfiguration(
+        val Default = SignedRequestConfiguration(
             supportedAlgorithms = listOf(JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512),
             supportedRequestUriMethods = SupportedRequestUriMethods.Default,
+            multiSignedRequestsPolicy = MultiSignedRequestsPolicy.NotSupported,
         )
     }
 }
@@ -378,8 +387,8 @@ enum class ErrorDispatchPolicy : java.io.Serializable {
  * At minimum, a wallet configuration should define at least a [supportedClientIdPrefixes]
  *
  * @param issuer an optional id for the wallet. If not provided defaults to [SelfIssued].
- * @param jarConfiguration options related to JWT Secure authorization requests.
- * If not provided, it will default to [JarConfiguration.Default]
+ * @param signedRequestConfiguration options related to JWT Secure authorization requests.
+ * If not provided, it will default to [SignedRequestConfiguration.Default]
  * @param responseEncryptionConfiguration whether wallet supports authorization response encryption. If not specified, it takes the default value
  * [ResponseEncryptionConfiguration.NotSupported].
  * @param vpConfiguration options about OpenId4VP.
@@ -390,7 +399,7 @@ enum class ErrorDispatchPolicy : java.io.Serializable {
  */
 data class OpenId4VPConfig(
     val issuer: Issuer? = SelfIssued,
-    val jarConfiguration: JarConfiguration = JarConfiguration.Default,
+    val signedRequestConfiguration: SignedRequestConfiguration = SignedRequestConfiguration.Default,
     val responseEncryptionConfiguration: ResponseEncryptionConfiguration = NotSupported,
     val vpConfiguration: VPConfiguration,
     val clock: Clock = Clock.systemDefaultZone(),
@@ -400,11 +409,19 @@ data class OpenId4VPConfig(
 ) {
     init {
         require(supportedClientIdPrefixes.isNotEmpty()) { "At least a supported client id prefix must be provided" }
+
+        if (signedRequestConfiguration.multiSignedRequestsPolicy is MultiSignedRequestsPolicy.Expect) {
+            val multiSignedExpectedPrefix = signedRequestConfiguration.multiSignedRequestsPolicy.clientPrefix
+            val supportedPrefixes = supportedClientIdPrefixes.map { it.prefix() }
+            require(multiSignedExpectedPrefix in supportedPrefixes) {
+                "Wrong configuration. Multi-singed requests policy must declare a supported client id prefix."
+            }
+        }
     }
 
     constructor(
         issuer: Issuer? = SelfIssued,
-        jarConfiguration: JarConfiguration = JarConfiguration.Default,
+        signedRequestConfiguration: SignedRequestConfiguration = SignedRequestConfiguration.Default,
         responseEncryptionConfiguration: ResponseEncryptionConfiguration = NotSupported,
         vpConfiguration: VPConfiguration,
         clock: Clock = Clock.systemDefaultZone(),
@@ -413,7 +430,7 @@ data class OpenId4VPConfig(
         vararg supportedClientIdPrefixes: SupportedClientIdPrefix,
     ) : this(
         issuer,
-        jarConfiguration,
+        signedRequestConfiguration,
         responseEncryptionConfiguration,
         vpConfiguration,
         clock,
@@ -432,6 +449,3 @@ data class OpenId4VPConfig(
 
 internal fun OpenId4VPConfig.supportedClientIdPrefix(prefix: ClientIdPrefix): SupportedClientIdPrefix? =
     supportedClientIdPrefixes.firstOrNull { it.prefix() == prefix }
-
-@Deprecated("Use OpenId4VPConfig instead", ReplaceWith("OpenId4VPConfig"))
-typealias SiopOpenId4VPConfig = OpenId4VPConfig

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ErrorDispatcher.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ErrorDispatcher.kt
@@ -32,6 +32,7 @@ interface ErrorDispatcher {
         is ResponseMode.QueryJwt -> encodeRedirectURI(error, errorDispatchDetails, encryptionParameters)
         is ResponseMode.Fragment -> encodeRedirectURI(error, errorDispatchDetails, encryptionParameters)
         is ResponseMode.FragmentJwt -> encodeRedirectURI(error, errorDispatchDetails, encryptionParameters)
+        else -> error("Unsupported response mode: ${errorDispatchDetails.responseMode} for error dispatching over HTTP")
     }
 
     /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/OpenId4VPSpec.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/OpenId4VPSpec.kt
@@ -32,6 +32,7 @@ object OpenId4VPSpec {
     const val CLIENT_ID_PREFIX_VERIFIER_ATTESTATION = "verifier_attestation"
     const val CLIENT_ID_PREFIX_X509_SAN_DNS = "x509_san_dns"
     const val CLIENT_ID_PREFIX_X509_HASH = "x509_hash"
+    const val CLIENT_ID_PREFIX_ORIGIN = "origin"
 
     const val AUTHORIZATION_REQUEST_OBJECT_TYPE = "oauth-authz-req+jwt"
 
@@ -39,6 +40,10 @@ object OpenId4VPSpec {
     const val RM_DIRECT_POST_JWT: String = "direct_post.jwt"
 
     const val RESPONSE_TYPE_VP_TOKEN: String = "vp_token"
+
+    const val STATE = "state"
+    const val ERROR = "error"
+    const val ERROR_DESCRIPTION = "error_description"
 
     const val WALLET_NONCE: String = "wallet_nonce"
     const val WALLET_METADATA: String = "wallet_metadata"
@@ -93,4 +98,10 @@ object OpenId4VPSpec {
     const val VERIFIER_INFO_FORMAT_JWT: String = "jwt"
     const val VERIFIER_INFO_DATA: String = "data"
     const val VERIFIER_INFO_CREDENTIAL_IDS = "credential_ids"
+
+    const val EXPECTED_ORIGINS = "expected_origins"
+
+    const val DC_API_EXCHANGE_PROTOCOL_UNSIGNED = "openid4vp-v1-unsigned"
+    const val DC_API_EXCHANGE_PROTOCOL_SIGNED = "openid4vp-v1-signed"
+    const val DC_API_EXCHANGE_PROTOCOL_MULTISIGNED = "openid4vp-v1-multisigned"
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/OpenId4Vp.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/OpenId4Vp.kt
@@ -39,7 +39,7 @@ sealed interface OpenId4Vp {
 
     companion object {
 
-        fun overHttp(
+        fun overRedirects(
             openId4VPConfig: OpenId4VPConfig,
             httpClient: HttpClient,
         ): OverHttp {
@@ -52,7 +52,7 @@ sealed interface OpenId4Vp {
                 OverHttp {}
         }
 
-        fun overDcAPI(
+        fun overDcApi(
             openId4VPConfig: OpenId4VPConfig,
             httpClient: HttpClient,
         ): OverDcAPI {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/OpenId4Vp.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/OpenId4Vp.kt
@@ -15,46 +15,53 @@
  */
 package eu.europa.ec.eudi.openid4vp
 
-import eu.europa.ec.eudi.openid4vp.OpenId4Vp.Companion.invoke
-import eu.europa.ec.eudi.openid4vp.internal.request.DefaultAuthorizationRequestResolver
-import eu.europa.ec.eudi.openid4vp.internal.response.DefaultDispatcher
+import eu.europa.ec.eudi.openid4vp.internal.request.DefaultRequestResolverOverDCApi
+import eu.europa.ec.eudi.openid4vp.internal.request.DefaultRequestResolverOverHttp
+import eu.europa.ec.eudi.openid4vp.internal.response.DefaultDispatcherOverDCApi
+import eu.europa.ec.eudi.openid4vp.internal.response.DefaultDispatcherOverHttp
 import io.ktor.client.*
 
 /**
- * An interface providing support for handling an OAuth2.0 request that represents OpenId4VP authorization.
+ * An interface providing support for handling an OAuth2.0 request that represents OpenId4VP authorization coming via the HTTP channel or
+ * the Digital Credentials API.
  *
- * To obtain an instance of [OpenId4Vp], method [invoke] can be used.
+ * To obtain an instance of [OpenId4Vp], either method [OpenId4Vp.overHttp()] or [OpenId4Vp.overDcApi()] can be used.
  *
- * @see AuthorizationRequestResolver
- * @see Dispatcher
+ * @see AuthorizationRequestOverHttpResolver
+ * @see AuthorizationRequestOverDCApiResolver
+ * @see DispatcherOverHttp
+ * @see DispatcherOverDCApi
  */
-interface OpenId4Vp : AuthorizationRequestResolver, Dispatcher, ErrorDispatcher {
+sealed interface OpenId4Vp {
+
+    interface OverHttp : AuthorizationRequestOverHttpResolver, DispatcherOverHttp, ErrorDispatcher, OpenId4Vp
+    interface OverDcAPI : AuthorizationRequestOverDCApiResolver, DispatcherOverDCApi, OpenId4Vp
 
     companion object {
 
-        /**
-         * Factory method to create a [OpenId4Vp].
-         *
-         * @param openId4VPConfig wallet's configuration
-         * @param httpClient A Ktor http client. This can be used to configure ktor
-         * to use a specific engine.
-         *
-         * @return a [OpenId4Vp]
-         */
-        operator fun invoke(
+        fun overHttp(
             openId4VPConfig: OpenId4VPConfig,
             httpClient: HttpClient,
-        ): OpenId4Vp {
-            val requestResolver = DefaultAuthorizationRequestResolver(openId4VPConfig, httpClient)
-            val dispatcher = DefaultDispatcher(httpClient)
+        ): OverHttp {
+            val requestResolver = DefaultRequestResolverOverHttp(openId4VPConfig, httpClient)
+            val dispatcher = DefaultDispatcherOverHttp(httpClient)
             return object :
-                AuthorizationRequestResolver by requestResolver,
-                Dispatcher by dispatcher,
+                AuthorizationRequestOverHttpResolver by requestResolver,
+                DispatcherOverHttp by dispatcher,
                 ErrorDispatcher by dispatcher,
-                OpenId4Vp {}
+                OverHttp {}
+        }
+
+        fun overDcAPI(
+            openId4VPConfig: OpenId4VPConfig,
+            httpClient: HttpClient,
+        ): OverDcAPI {
+            val requestResolver = DefaultRequestResolverOverDCApi(openId4VPConfig, httpClient)
+            val dispatcher = DefaultDispatcherOverDCApi()
+            return object :
+                AuthorizationRequestOverDCApiResolver by requestResolver,
+                DispatcherOverDCApi by dispatcher,
+                OverDcAPI {}
         }
     }
 }
-
-@Deprecated("Use OpenId4Vp instead", ReplaceWith("OpenId4Vp"))
-typealias SiopOpenId4Vp = OpenId4Vp

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ResponseDispatching.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ResponseDispatching.kt
@@ -15,7 +15,6 @@
  */
 package eu.europa.ec.eudi.openid4vp
 
-import eu.europa.ec.eudi.openid4vp.ResolvedRequestObject.*
 import kotlinx.serialization.json.JsonObject
 import java.net.URI
 
@@ -160,5 +159,9 @@ interface DispatcherOverDCApi {
         request: ResolvedRequestObject,
         consensus: Consensus,
         encryptionParameters: EncryptionParameters? = null,
+    ): JsonObject
+
+    fun assembleErrorResponse(
+        error: AuthorizationRequestError,
     ): JsonObject
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ResponseDispatching.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ResponseDispatching.kt
@@ -150,7 +150,7 @@ interface DispatcherOverHttp {
 }
 
 /**
- * Given a [request][ResolvedRequestObject] send over DC API chanel and holder's [consensus][Consensus] this interface
+ * Given a [request][ResolvedRequestObject] send over DC API channel and holder's [consensus][Consensus] this interface
  * assembles an appropriate authorization response.
  */
 interface DispatcherOverDCApi {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ResponseDispatching.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ResponseDispatching.kt
@@ -15,6 +15,8 @@
  */
 package eu.europa.ec.eudi.openid4vp
 
+import eu.europa.ec.eudi.openid4vp.ResolvedRequestObject.*
+import kotlinx.serialization.json.JsonObject
 import java.net.URI
 
 /**
@@ -73,9 +75,9 @@ sealed interface DispatchOutcome : java.io.Serializable {
 
 /**
  * This interface assembles an appropriate authorization response given a [request][ResolvedRequestObject]
- * and holder's [consensus][Consensus] and then dispatches it to the verifier
+ * and holder's [consensus][Consensus] and then dispatches it to the verifier over HTTP channel
  */
-interface Dispatcher {
+interface DispatcherOverHttp {
 
     /**
      * Assembles an appropriate authorization response given a [request][request]
@@ -106,6 +108,7 @@ interface Dispatcher {
             is ResponseMode.QueryJwt -> encodeRedirectURI(request, consensus, encryptionParameters)
             is ResponseMode.Fragment -> encodeRedirectURI(request, consensus, null)
             is ResponseMode.FragmentJwt -> encodeRedirectURI(request, consensus, encryptionParameters)
+            else -> error("Unsupported response mode: ${request.responseMode} for dispatching over HTTP")
         }
 
     /**
@@ -145,4 +148,17 @@ interface Dispatcher {
         consensus: Consensus,
         encryptionParameters: EncryptionParameters? = null,
     ): DispatchOutcome.RedirectURI
+}
+
+/**
+ * Given a [request][ResolvedRequestObject] send over DC API chanel and holder's [consensus][Consensus] this interface
+ * assembles an appropriate authorization response.
+ */
+interface DispatcherOverDCApi {
+
+    suspend fun assembleResponse(
+        request: ResolvedRequestObject,
+        consensus: Consensus,
+        encryptionParameters: EncryptionParameters? = null,
+    ): JsonObject
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Types.kt
@@ -108,6 +108,12 @@ enum class ClientIdPrefix {
      */
     X509Hash,
 
+    /**
+     * This prefix is intended to be used only when an authorization is performed over the DC API channel.
+     * It is not a prefix accepted in requests and is used to set the audience of the Credential Presentation response.
+     */
+    ORIGIN,
+
     ;
 
     /**
@@ -115,7 +121,7 @@ enum class ClientIdPrefix {
      */
     fun permitsSignedRequestObjects(): Boolean = when (this) {
         RedirectUri -> false
-        PreRegistered, VerifierAttestation, OpenIdFederation, DecentralizedIdentifier, X509SanDns, X509Hash -> true
+        PreRegistered, VerifierAttestation, OpenIdFederation, DecentralizedIdentifier, X509SanDns, X509Hash, ORIGIN -> true
     }
 
     companion object {
@@ -126,6 +132,7 @@ enum class ClientIdPrefix {
             OpenId4VPSpec.CLIENT_ID_PREFIX_VERIFIER_ATTESTATION -> VerifierAttestation
             OpenId4VPSpec.CLIENT_ID_PREFIX_X509_SAN_DNS -> X509SanDns
             OpenId4VPSpec.CLIENT_ID_PREFIX_X509_HASH -> X509Hash
+            OpenId4VPSpec.CLIENT_ID_PREFIX_ORIGIN -> ORIGIN
             else -> null
         }
     }
@@ -154,6 +161,7 @@ data class VerifierId(
             ClientIdPrefix.VerifierAttestation -> OpenId4VPSpec.CLIENT_ID_PREFIX_VERIFIER_ATTESTATION
             ClientIdPrefix.X509SanDns -> OpenId4VPSpec.CLIENT_ID_PREFIX_X509_SAN_DNS
             ClientIdPrefix.X509Hash -> OpenId4VPSpec.CLIENT_ID_PREFIX_X509_HASH
+            ClientIdPrefix.ORIGIN -> OpenId4VPSpec.CLIENT_ID_PREFIX_ORIGIN
         }
 
         buildString {
@@ -185,6 +193,7 @@ data class VerifierId(
                     ClientIdPrefix.VerifierAttestation -> VerifierId(prefix, originalClientId)
                     ClientIdPrefix.X509SanDns -> VerifierId(prefix, originalClientId)
                     ClientIdPrefix.X509Hash -> VerifierId(prefix, originalClientId)
+                    ClientIdPrefix.ORIGIN -> VerifierId(prefix, originalClientId)
                     null -> preRegistered()
                 }
             }
@@ -212,6 +221,14 @@ sealed interface ResponseMode : java.io.Serializable {
     data class FragmentJwt(val redirectUri: URI) : ResponseMode
     data class DirectPost(val responseURI: URL) : ResponseMode
     data class DirectPostJwt(val responseURI: URL) : ResponseMode
+
+    data object DCApi : ResponseMode {
+        private fun readResolve(): Any = DCApi
+    }
+
+    data object DCApiJwt : ResponseMode {
+        private fun readResolve(): Any = DCApiJwt
+    }
 }
 
 internal fun ResponseMode.requiresEncryption() =
@@ -222,6 +239,8 @@ internal fun ResponseMode.requiresEncryption() =
         is ResponseMode.FragmentJwt -> true
         is ResponseMode.Query -> false
         is ResponseMode.QueryJwt -> true
+        ResponseMode.DCApi -> false
+        ResponseMode.DCApiJwt -> true
     }
 
 typealias Jwt = String

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Types.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Types.kt
@@ -193,7 +193,7 @@ data class VerifierId(
                     ClientIdPrefix.VerifierAttestation -> VerifierId(prefix, originalClientId)
                     ClientIdPrefix.X509SanDns -> VerifierId(prefix, originalClientId)
                     ClientIdPrefix.X509Hash -> VerifierId(prefix, originalClientId)
-                    ClientIdPrefix.ORIGIN -> VerifierId(prefix, originalClientId)
+                    ClientIdPrefix.ORIGIN -> invalid("'${ClientIdPrefix.ORIGIN}' cannot be used as a Client ID prefix")
                     null -> preRegistered()
                 }
             }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/RFC7515Spec.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/RFC7515Spec.kt
@@ -100,7 +100,7 @@ internal sealed interface JwsJson {
         /**
          * Parses an input string representing a JWS in compact form into a [JwsJson.Flattened] object.
          */
-        fun from(compact: String): Result<JwsJson> = runCatchingCancellable {
+        fun fromCompact(compact: String): Result<Flattened> = runCatchingCancellable {
             require(compact.isNotBlank()) { "Input must not be empty" }
             compact.split(".").let { parts ->
                 require(parts.size == 3) { "Input must be a JWS in compact form" }
@@ -109,7 +109,7 @@ internal sealed interface JwsJson {
                     put(RFC7515Spec.JWS_JSON_SYNTAX_PAYLOAD, parts[1])
                     put(RFC7515Spec.JWS_JSON_SYNTAX_SIGNATURE, parts[2])
                 }
-                Json.decodeFromJsonElement<JwsJson>(jwsJsonObject)
+                Json.decodeFromJsonElement<Flattened>(jwsJsonObject)
             }
         }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/AuthorizationRequest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/AuthorizationRequest.kt
@@ -46,22 +46,24 @@ internal data class UnvalidatedRequestObject(
 
 internal sealed interface ReceivedRequest {
     data class Unsigned(val requestObject: UnvalidatedRequestObject) : ReceivedRequest
-    data class Signed(val jwsJson: JwsJson) : ReceivedRequest {
+    data class Signed(val jwsJson: JwsJson.Flattened) : ReceivedRequest {
         companion object {
             operator fun invoke(signedJwt: SignedJWT): Signed = Signed(JwsJson.from(signedJwt).getOrThrow())
         }
     }
+    data class MultiSigned(val jwsJson: JwsJson.General) : ReceivedRequest
+
     companion object
 }
 
 /**
  * Decomposes a Nimbus [SignedJWT] into [JwsJson].
  */
-private fun JwsJson.Companion.from(signedJwt: SignedJWT): Result<JwsJson> = runCatchingCancellable {
+private fun JwsJson.Companion.from(signedJwt: SignedJWT): Result<JwsJson.Flattened> = runCatchingCancellable {
     require(signedJwt.state == JWSObject.State.SIGNED) { "JWS is not signed" }
     val compactFormString =
         "${signedJwt.header.toBase64URL()}.${signedJwt.payload.toBase64URL()}.${signedJwt.signature}"
-    JwsJson.from(compactFormString).getOrThrow()
+    JwsJson.fromCompact(compactFormString).getOrThrow()
 }
 
 internal fun JwsJson.Flattened.toSignedJwt(): SignedJWT =

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/AuthorizationRequest.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/AuthorizationRequest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vp.internal.request
+
+import com.nimbusds.jose.JWSObject
+import com.nimbusds.jwt.SignedJWT
+import eu.europa.ec.eudi.openid4vp.OpenId4VPSpec
+import eu.europa.ec.eudi.openid4vp.internal.JwsJson
+import eu.europa.ec.eudi.openid4vp.runCatchingCancellable
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * The data of an OpenID4VP authorization request without any validation and regardless of the way they sent to the wallet.
+ */
+@Serializable
+internal data class UnvalidatedRequestObject(
+    @SerialName("client_metadata") val clientMetaData: JsonObject? = null,
+    @SerialName(OpenId4VPSpec.NONCE) val nonce: String? = null,
+    @SerialName("client_id") val clientId: String? = null,
+    @SerialName("response_type") val responseType: String? = null,
+    @SerialName("response_mode") val responseMode: String? = null,
+    @SerialName(OpenId4VPSpec.RESPONSE_URI) val responseUri: String? = null,
+    @SerialName(OpenId4VPSpec.DCQL_QUERY) val dcqlQuery: JsonObject? = null,
+    @SerialName("redirect_uri") val redirectUri: String? = null,
+    @SerialName("scope") val scope: String? = null,
+    @SerialName("state") val state: String? = null,
+    @SerialName(OpenId4VPSpec.TRANSACTION_DATA) val transactionData: TransactionDataTO? = null,
+    @SerialName(OpenId4VPSpec.VERIFIER_INFO) val verifierInfo: VerifierInfoTO? = null,
+    @SerialName(OpenId4VPSpec.EXPECTED_ORIGINS) val expectedOrigins: List<String>? = null,
+)
+
+internal sealed interface ReceivedRequest {
+    data class Unsigned(val requestObject: UnvalidatedRequestObject) : ReceivedRequest
+    data class Signed(val jwsJson: JwsJson) : ReceivedRequest {
+        companion object {
+            operator fun invoke(signedJwt: SignedJWT): Signed = Signed(JwsJson.from(signedJwt).getOrThrow())
+        }
+    }
+    companion object
+}
+
+/**
+ * Decomposes a Nimbus [SignedJWT] into [JwsJson].
+ */
+private fun JwsJson.Companion.from(signedJwt: SignedJWT): Result<JwsJson> = runCatchingCancellable {
+    require(signedJwt.state == JWSObject.State.SIGNED) { "JWS is not signed" }
+    val compactFormString =
+        "${signedJwt.header.toBase64URL()}.${signedJwt.payload.toBase64URL()}.${signedJwt.signature}"
+    JwsJson.from(compactFormString).getOrThrow()
+}
+
+internal fun JwsJson.Flattened.toSignedJwt(): SignedJWT =
+    SignedJWT.parse("$protected.$payload.$signature")

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultRequestResolverOverDCApi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultRequestResolverOverDCApi.kt
@@ -57,9 +57,9 @@ internal class DefaultRequestResolverOverDCApi(
     private suspend fun HttpClient.resolveRequestObject(protocol: String, origin: String, requestData: JsonObject): Resolution {
         try {
             val receivedRequest = ReceivedRequest.make(requestData).getOrThrow()
-            val dcApiProtocol = DCApiExchangeProtocol.from(protocol)
+            val exchangeProtocol = DCApiExchangeProtocol.from(protocol)
 
-            dcApiProtocol assertMatches receivedRequest
+            exchangeProtocol assertMatches receivedRequest
 
             val authenticatedRequest = authenticateRequest(origin, receivedRequest)
             val resolved = validateRequestObject(origin, authenticatedRequest, receivedRequest is Signed)
@@ -84,9 +84,8 @@ internal class DefaultRequestResolverOverDCApi(
         return requestValidator.validateDCApiRequestObject(origin, authenticatedRequest, isSigned)
     }
 
-    fun ReceivedRequest.Companion.make(requestData: JsonObject): Result<ReceivedRequest> = runCatching {
+    private fun ReceivedRequest.Companion.make(requestData: JsonObject): Result<ReceivedRequest> = runCatching {
         val requestValue = requestData["request"]
-
         when {
             requestValue != null && requestValue is JsonObject -> {
                 val jwsJson = jsonSupport.decodeFromJsonElement<JwsJson>(requestValue)
@@ -103,7 +102,7 @@ internal class DefaultRequestResolverOverDCApi(
     }
 }
 
-internal infix fun DCApiExchangeProtocol.assertMatches(receivedRequest: ReceivedRequest) = when (this) {
+private infix fun DCApiExchangeProtocol.assertMatches(receivedRequest: ReceivedRequest) = when (this) {
     DCApiExchangeProtocol.UNSIGNED ->
         ensure(receivedRequest is Unsigned) {
             asMissMatchException(

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultRequestResolverOverDCApi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultRequestResolverOverDCApi.kt
@@ -19,8 +19,7 @@ import eu.europa.ec.eudi.openid4vp.*
 import eu.europa.ec.eudi.openid4vp.internal.JwsJson
 import eu.europa.ec.eudi.openid4vp.internal.ensure
 import eu.europa.ec.eudi.openid4vp.internal.jsonSupport
-import eu.europa.ec.eudi.openid4vp.internal.request.ReceivedRequest.Signed
-import eu.europa.ec.eudi.openid4vp.internal.request.ReceivedRequest.Unsigned
+import eu.europa.ec.eudi.openid4vp.internal.request.ReceivedRequest.*
 import io.ktor.client.*
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -88,12 +87,12 @@ internal class DefaultRequestResolverOverDCApi(
         val requestValue = requestData["request"]
         when {
             requestValue != null && requestValue is JsonObject -> {
-                val jwsJson = jsonSupport.decodeFromJsonElement<JwsJson>(requestValue)
-                Signed(jwsJson)
+                val jwsJson = jsonSupport.decodeFromJsonElement<JwsJson.General>(requestValue)
+                MultiSigned(jwsJson)
             }
 
             requestValue != null && requestValue is JsonPrimitive -> {
-                val jwsJson = JwsJson.from(requestValue.jsonPrimitive.content).getOrThrow()
+                val jwsJson = JwsJson.fromCompact(requestValue.jsonPrimitive.content).getOrThrow()
                 Signed(jwsJson)
             }
 
@@ -111,7 +110,7 @@ private infix fun DCApiExchangeProtocol.assertMatches(receivedRequest: ReceivedR
         }
 
     DCApiExchangeProtocol.SIGNED ->
-        ensure(receivedRequest is Signed && receivedRequest.jwsJson is JwsJson.Flattened) {
+        ensure(receivedRequest is Signed) {
             asMissMatchException(
                 "Exchange protocol is ${OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_SIGNED} but request's format is not JWS " +
                     "compact serialization.",
@@ -119,7 +118,7 @@ private infix fun DCApiExchangeProtocol.assertMatches(receivedRequest: ReceivedR
         }
 
     DCApiExchangeProtocol.MULTISIGNED ->
-        ensure(receivedRequest is Signed && receivedRequest.jwsJson is JwsJson.General) {
+        ensure(receivedRequest is MultiSigned) {
             asMissMatchException(
                 "Exchange protocol is ${OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_MULTISIGNED} but request's format is not " +
                     "JWS general serialization.",

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultRequestResolverOverDCApi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultRequestResolverOverDCApi.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vp.internal.request
+
+import eu.europa.ec.eudi.openid4vp.*
+import eu.europa.ec.eudi.openid4vp.internal.JwsJson
+import eu.europa.ec.eudi.openid4vp.internal.ensure
+import eu.europa.ec.eudi.openid4vp.internal.jsonSupport
+import eu.europa.ec.eudi.openid4vp.internal.request.ReceivedRequest.Signed
+import eu.europa.ec.eudi.openid4vp.internal.request.ReceivedRequest.Unsigned
+import io.ktor.client.*
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonPrimitive
+
+internal enum class DCApiExchangeProtocol {
+    UNSIGNED,
+    SIGNED,
+    MULTISIGNED,
+    ;
+
+    companion object {
+        fun from(protocol: String): DCApiExchangeProtocol =
+            when (protocol) {
+                OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_UNSIGNED -> UNSIGNED
+                OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_SIGNED -> SIGNED
+                OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_MULTISIGNED -> MULTISIGNED
+                else -> throw ResolutionError.UnsupportedDcApiExchangeProtocol.asException()
+            }
+    }
+}
+
+internal class DefaultRequestResolverOverDCApi(
+    private val openId4VPConfig: OpenId4VPConfig,
+    private val httpClient: HttpClient,
+) : AuthorizationRequestOverDCApiResolver {
+
+    override suspend fun resolveRequestObject(protocol: String, origin: String, requestData: JsonObject): Resolution =
+        with(httpClient) {
+            this.resolveRequestObject(protocol, origin, requestData)
+        }
+
+    private suspend fun HttpClient.resolveRequestObject(protocol: String, origin: String, requestData: JsonObject): Resolution {
+        try {
+            val receivedRequest = ReceivedRequest.make(requestData).getOrThrow()
+            val dcApiProtocol = DCApiExchangeProtocol.from(protocol)
+
+            dcApiProtocol assertMatches receivedRequest
+
+            val authenticatedRequest = authenticateRequest(origin, receivedRequest)
+            val resolved = validateRequestObject(origin, authenticatedRequest, receivedRequest is Signed)
+
+            return Resolution.Success(resolved)
+        } catch (e: AuthorizationRequestException) {
+            return Resolution.Invalid(e.error, null)
+        }
+    }
+
+    private suspend fun HttpClient.authenticateRequest(origin: String, receivedRequest: ReceivedRequest): AuthenticatedRequest {
+        val requestAuthenticator = RequestAuthenticator(openId4VPConfig, this)
+        return requestAuthenticator.authenticateRequestOverDCApi(origin, receivedRequest)
+    }
+
+    private fun validateRequestObject(
+        origin: String,
+        authenticatedRequest: AuthenticatedRequest,
+        isSigned: Boolean,
+    ): ResolvedRequestObject {
+        val requestValidator = RequestObjectValidator(openId4VPConfig)
+        return requestValidator.validateDCApiRequestObject(origin, authenticatedRequest, isSigned)
+    }
+
+    fun ReceivedRequest.Companion.make(requestData: JsonObject): Result<ReceivedRequest> = runCatching {
+        val requestValue = requestData["request"]
+
+        when {
+            requestValue != null && requestValue is JsonObject -> {
+                val jwsJson = jsonSupport.decodeFromJsonElement<JwsJson>(requestValue)
+                Signed(jwsJson)
+            }
+
+            requestValue != null && requestValue is JsonPrimitive -> {
+                val jwsJson = JwsJson.from(requestValue.jsonPrimitive.content).getOrThrow()
+                Signed(jwsJson)
+            }
+
+            else -> Unsigned(jsonSupport.decodeFromJsonElement(requestData))
+        }
+    }
+}
+
+internal infix fun DCApiExchangeProtocol.assertMatches(receivedRequest: ReceivedRequest) = when (this) {
+    DCApiExchangeProtocol.UNSIGNED ->
+        ensure(receivedRequest is Unsigned) {
+            asMissMatchException(
+                "Exchange protocol is ${OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_UNSIGNED} but request is not Unsigned.",
+            )
+        }
+
+    DCApiExchangeProtocol.SIGNED ->
+        ensure(receivedRequest is Signed && receivedRequest.jwsJson is JwsJson.Flattened) {
+            asMissMatchException(
+                "Exchange protocol is ${OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_SIGNED} but request's format is not JWS " +
+                    "compact serialization.",
+            )
+        }
+
+    DCApiExchangeProtocol.MULTISIGNED ->
+        ensure(receivedRequest is Signed && receivedRequest.jwsJson is JwsJson.General) {
+            asMissMatchException(
+                "Exchange protocol is ${OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_MULTISIGNED} but request's format is not " +
+                    "JWS general serialization.",
+            )
+        }
+}
+
+private fun asMissMatchException(reason: String): Throwable =
+    ResolutionError.DcApiExchangeProtocolNotMatchesReceivedRequest(reason).asException()

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultRequestResolverOverHttp.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultRequestResolverOverHttp.kt
@@ -15,11 +15,8 @@
  */
 package eu.europa.ec.eudi.openid4vp.internal.request
 
-import com.nimbusds.jose.JWSObject
-import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.openid4vp.*
 import eu.europa.ec.eudi.openid4vp.internal.JwsJson
-import eu.europa.ec.eudi.openid4vp.internal.JwsJson.Companion.flatten
 import eu.europa.ec.eudi.openid4vp.internal.decodePayloadAs
 import eu.europa.ec.eudi.openid4vp.internal.ensure
 import eu.europa.ec.eudi.openid4vp.internal.jsonSupport
@@ -28,7 +25,6 @@ import eu.europa.ec.eudi.openid4vp.internal.request.UnvalidatedRequest.JwtSecure
 import io.ktor.client.*
 import io.ktor.http.*
 import io.ktor.util.*
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*
 import java.net.URI
@@ -61,25 +57,6 @@ internal value class TransactionDataTO(val value: JsonArray) {
     val values: List<String>
         get() = value.map { it.jsonPrimitive.content }
 }
-
-/**
- * The data of an OpenID4VP authorization request without any validation and regardless of the way they sent to the wallet.
- */
-@Serializable
-internal data class UnvalidatedRequestObject(
-    @SerialName("client_metadata") val clientMetaData: JsonObject? = null,
-    @SerialName(OpenId4VPSpec.NONCE) val nonce: String? = null,
-    @SerialName("client_id") val clientId: String? = null,
-    @SerialName("response_type") val responseType: String? = null,
-    @SerialName("response_mode") val responseMode: String? = null,
-    @SerialName(OpenId4VPSpec.RESPONSE_URI) val responseUri: String? = null,
-    @SerialName(OpenId4VPSpec.DCQL_QUERY) val dcqlQuery: JsonObject? = null,
-    @SerialName("redirect_uri") val redirectUri: String? = null,
-    @SerialName("scope") val scope: String? = null,
-    @SerialName("state") val state: String? = null,
-    @SerialName(OpenId4VPSpec.TRANSACTION_DATA) val transactionData: TransactionDataTO? = null,
-    @SerialName(OpenId4VPSpec.VERIFIER_INFO) val verifierInfo: VerifierInfoTO? = null,
-)
 
 enum class RequestUriMethod {
     GET, POST
@@ -192,34 +169,10 @@ internal sealed interface UnvalidatedRequest {
     }
 }
 
-internal sealed interface ReceivedRequest {
-    data class Unsigned(val requestObject: UnvalidatedRequestObject) : ReceivedRequest
-    data class Signed(val jwsJson: JwsJson) : ReceivedRequest {
-        companion object {
-            operator fun invoke(signedJwt: SignedJWT): Signed = Signed(JwsJson.from(signedJwt).getOrThrow())
-        }
-    }
-}
-
-/**
- * Decomposes a Nimbus [SignedJWT] into [JwsJson].
- */
-private fun JwsJson.Companion.from(signedJwt: SignedJWT): Result<JwsJson> = runCatchingCancellable {
-    require(signedJwt.state == JWSObject.State.SIGNED) { "JWS is not signed" }
-    val compactFormString =
-        "${signedJwt.header.toBase64URL()}.${signedJwt.payload.toBase64URL()}.${signedJwt.signature}"
-    JwsJson.from(compactFormString).getOrThrow()
-}
-
-internal fun ReceivedRequest.Signed.toSignedJwts(): List<SignedJWT> =
-    jwsJson.flatten().map {
-        SignedJWT.parse("${it.protected}.${it.payload}.${it.signature}")
-    }
-
-internal class DefaultAuthorizationRequestResolver(
+internal class DefaultRequestResolverOverHttp(
     private val openId4VPConfig: OpenId4VPConfig,
     private val httpClient: HttpClient,
-) : AuthorizationRequestResolver {
+) : AuthorizationRequestOverHttpResolver {
 
     override suspend fun resolveRequestUri(uri: String): Resolution =
         with(httpClient) {
@@ -240,7 +193,7 @@ internal class DefaultAuthorizationRequestResolver(
             } catch (e: AuthorizationRequestException) {
                 val dispatchDetails =
                     when (openId4VPConfig.errorDispatchPolicy) {
-                        ErrorDispatchPolicy.AllClients -> dispatchDetailsOrNull(fetchedRequest, openId4VPConfig)
+                        ErrorDispatchPolicy.AllClients -> dispatchErrorDetailsOrNull(fetchedRequest, openId4VPConfig)
                         ErrorDispatchPolicy.OnlyAuthenticatedClients -> null
                     }
                 return Resolution.Invalid(e.error, dispatchDetails)
@@ -250,7 +203,7 @@ internal class DefaultAuthorizationRequestResolver(
             try {
                 validateRequestObject(authenticatedRequest)
             } catch (e: AuthorizationRequestException) {
-                val dispatchDetails = dispatchDetailsOrNull(authenticatedRequest.requestObject, openId4VPConfig)
+                val dispatchDetails = dispatchErrorDetailsOrNull(authenticatedRequest.requestObject, openId4VPConfig)
                 return Resolution.Invalid(e.error, dispatchDetails)
             }
 
@@ -259,7 +212,7 @@ internal class DefaultAuthorizationRequestResolver(
 
     private fun validateRequestObject(authenticatedRequest: AuthenticatedRequest): ResolvedRequestObject {
         val requestValidator = RequestObjectValidator(openId4VPConfig)
-        return requestValidator.validateRequestObject(authenticatedRequest)
+        return requestValidator.validateHttpRequestObject(authenticatedRequest)
     }
 
     private suspend fun HttpClient.fetchRequest(uri: String): ReceivedRequest {
@@ -270,20 +223,20 @@ internal class DefaultAuthorizationRequestResolver(
 
     private suspend fun HttpClient.authenticateRequest(receivedRequest: ReceivedRequest): AuthenticatedRequest {
         val requestAuthenticator = RequestAuthenticator(openId4VPConfig, this)
-        return requestAuthenticator.authenticate(receivedRequest)
+        return requestAuthenticator.authenticateRequestOverHttp(receivedRequest)
     }
 }
 
 /**
  * Creates an invalid resolution for errors that manifested while trying to authenticate a Client.
  */
-private fun dispatchDetailsOrNull(
+private fun dispatchErrorDetailsOrNull(
     fetchedRequest: ReceivedRequest,
     openId4VPConfig: OpenId4VPConfig,
 ): ErrorDispatchDetails? =
     when (fetchedRequest) {
-        is ReceivedRequest.Signed -> dispatchDetailsOrNull(fetchedRequest.jwsJson, openId4VPConfig)
-        is ReceivedRequest.Unsigned -> dispatchDetailsOrNull(fetchedRequest.requestObject, openId4VPConfig)
+        is ReceivedRequest.Signed -> dispatchErrorDetailsOrNull(fetchedRequest.jwsJson, openId4VPConfig)
+        is ReceivedRequest.Unsigned -> dispatchErrorDetailsOrNull(fetchedRequest.requestObject, openId4VPConfig)
     }
 
 /**
@@ -295,7 +248,7 @@ private fun dispatchDetailsOrNull(
  * * the response mode requires encryption, and we have resolved Client metadata that contains encryption parameters compatible with
  * the configuration of the Wallet
  */
-private fun dispatchDetailsOrNull(
+private fun dispatchErrorDetailsOrNull(
     unvalidatedRequest: UnvalidatedRequestObject,
     openId4VPConfig: OpenId4VPConfig,
 ): ErrorDispatchDetails? {
@@ -353,12 +306,12 @@ private fun UnvalidatedRequestObject.responseMode(): ResponseMode? {
     }
 }
 
-private fun dispatchDetailsOrNull(
+private fun dispatchErrorDetailsOrNull(
     jwsJson: JwsJson,
     openId4VPConfig: OpenId4VPConfig,
 ): ErrorDispatchDetails? =
     runCatchingCancellable {
-        dispatchDetailsOrNull(
+        dispatchErrorDetailsOrNull(
             jwsJson.decodePayloadAs<UnvalidatedRequestObject>(),
             openId4VPConfig,
         )

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultRequestResolverOverHttp.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/DefaultRequestResolverOverHttp.kt
@@ -237,6 +237,7 @@ private fun dispatchErrorDetailsOrNull(
     when (fetchedRequest) {
         is ReceivedRequest.Signed -> dispatchErrorDetailsOrNull(fetchedRequest.jwsJson, openId4VPConfig)
         is ReceivedRequest.Unsigned -> dispatchErrorDetailsOrNull(fetchedRequest.requestObject, openId4VPConfig)
+        is ReceivedRequest.MultiSigned -> error("Multisigned requests not expected over redirects")
     }
 
 /**

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticator.kt
@@ -83,14 +83,21 @@ internal class RequestAuthenticator(openId4VPConfig: OpenId4VPConfig, httpClient
             is ReceivedRequest.Unsigned -> {
                 AuthenticatedRequest(client, request.requestObject)
             }
-
-            is ReceivedRequest.Signed -> {
+            else -> {
                 requireNotNull(signedJwt) {
                     "Expected a signed request but was not."
                 }
-                val requestObject = signedJwt.requestObject()
-                    .extendWithHeaderAttributes(signedJwt.header)
-                with(signatureVerifier) { verifySignature(client, signedJwt) }
+                val requestObject = when (request) {
+                    is ReceivedRequest.Signed ->
+                        signedJwt.requestObject()
+                    is ReceivedRequest.MultiSigned ->
+                        signedJwt.requestObject()
+                            .extendWithHeaderAttributes(signedJwt.header)
+                    else -> error("Cannot happen")
+                }
+                with(signatureVerifier) {
+                    verifySignature(client, signedJwt)
+                }
                 AuthenticatedRequest(client, requestObject)
             }
         }
@@ -103,9 +110,12 @@ internal class RequestAuthenticator(openId4VPConfig: OpenId4VPConfig, httpClient
                 AuthenticatedRequest(client, request.requestObject)
             }
             is ReceivedRequest.Signed -> {
-                val signedJwt = request.ensureSingleSignedRequest()
+                val signedJwt = request.jwsJson.toSignedJwt()
                 with(signatureVerifier) { verifySignature(client, signedJwt) }
                 AuthenticatedRequest(client, signedJwt.requestObject())
+            }
+            is ReceivedRequest.MultiSigned -> {
+                error("Multisigned requests are not expected over redirects.")
             }
         }
     }
@@ -124,20 +134,15 @@ internal class ClientAuthenticator(private val openId4VPConfig: OpenId4VPConfig)
             is ReceivedRequest.Unsigned -> Origin(origin) to null
 
             is ReceivedRequest.Signed -> {
-                val jwsJson = request.jwsJson
-                when (jwsJson) {
-                    is JwsJson.Flattened -> {
-                        val signedJwt = jwsJson.toSignedJwt()
-                        val (originalClientId, clientIdPrefix) = originalClientIdAndPrefix(signedJwt.requestObject())
-                        authenticateClientPrefix(originalClientId, clientIdPrefix, signedJwt) to signedJwt
-                    }
+                val signedJwt = request.jwsJson.toSignedJwt()
+                val (originalClientId, clientIdPrefix) = originalClientIdAndPrefix(signedJwt.requestObject())
+                authenticateClientPrefix(originalClientId, clientIdPrefix, signedJwt) to signedJwt
+            }
 
-                    is JwsJson.General -> {
-                        val policy = openId4VPConfig.signedRequestConfiguration.multiSignedRequestsPolicy
-                        val (originalClientId, clientIdPrefix, signedJwt) = jwsJson apply policy
-                        authenticateClientPrefix(originalClientId, clientIdPrefix, signedJwt) to signedJwt
-                    }
-                }
+            is ReceivedRequest.MultiSigned -> {
+                val policy = openId4VPConfig.signedRequestConfiguration.multiSignedRequestsPolicy
+                val (originalClientId, clientIdPrefix, signedJwt) = request.jwsJson apply policy
+                authenticateClientPrefix(originalClientId, clientIdPrefix, signedJwt) to signedJwt
             }
         }
 
@@ -159,9 +164,11 @@ internal class ClientAuthenticator(private val openId4VPConfig: OpenId4VPConfig)
         val (signedRequest, requestObject) = when (request) {
             is ReceivedRequest.Unsigned -> null to request.requestObject
             is ReceivedRequest.Signed -> {
-                val signedRequest = request.ensureSingleSignedRequest()
+                val signedRequest = request.jwsJson.toSignedJwt()
                 signedRequest to signedRequest.requestObject()
             }
+            is ReceivedRequest.MultiSigned ->
+                error("Multisigned requests are not expected over redirects.")
         }
         val (originalClientId, clientIdPrefix) = originalClientIdAndPrefix(requestObject)
         return authenticateClientPrefix(originalClientId, clientIdPrefix, signedRequest)
@@ -293,11 +300,6 @@ internal class ClientAuthenticator(private val openId4VPConfig: OpenId4VPConfig)
         return pubCertChain
     }
 }
-
-private fun ReceivedRequest.Signed.ensureSingleSignedRequest(): SignedJWT =
-    ensure(jwsJson is JwsJson.Flattened) {
-        invalidJarJwt("Multi-signed authorization requests is not expected.")
-    }.let { jwsJson.toSignedJwt() }
 
 private suspend fun lookupKeyByDID(
     signedRequest: SignedJWT,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticator.kt
@@ -185,11 +185,6 @@ internal class ClientAuthenticator(private val openId4VPConfig: OpenId4VPConfig)
         }.firstOrNull()
             ?: throw NoMatchingClientPrefixInMultiSignedRequest.asException()
 
-    private fun JwsJson.Flattened.assertVerifierInProtectedHeader() {
-        // If verifier_info exists in unprotected header cannot be trusted
-        // if verifier_info exists in unprotected header but not in protected fail
-    }
-
     private fun JwsJson.Flattened.clientIdFromProtectedHeader(): String? {
         val protectedHeader: JsonObject? = protected?.decodeAs()
         return protectedHeader?.get("client_id")?.let {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticator.kt
@@ -17,6 +17,7 @@ package eu.europa.ec.eudi.openid4vp.internal.request
 
 import com.nimbusds.jose.JOSEException
 import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.jwk.AsymmetricJWK
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.JWKSet
@@ -33,8 +34,11 @@ import com.nimbusds.jwt.proc.DefaultJWTProcessor
 import com.nimbusds.jwt.proc.JWTClaimsSetVerifier
 import com.nimbusds.jwt.util.DateUtils
 import eu.europa.ec.eudi.openid4vp.*
+import eu.europa.ec.eudi.openid4vp.RequestValidationError.NoMatchingClientPrefixInMultiSignedRequest
 import eu.europa.ec.eudi.openid4vp.SupportedClientIdPrefix.Preregistered
 import eu.europa.ec.eudi.openid4vp.internal.*
+import eu.europa.ec.eudi.openid4vp.internal.JwsJson.Companion.flatten
+import eu.europa.ec.eudi.openid4vp.internal.request.AuthenticatedClient.*
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
@@ -42,6 +46,8 @@ import io.ktor.client.request.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import java.net.URI
 import java.security.MessageDigest
 import java.security.PublicKey
@@ -59,6 +65,7 @@ internal sealed interface AuthenticatedClient {
     data class VerifierAttestation(val clientId: OriginalClientId, val claims: VerifierAttestationClaims) : AuthenticatedClient
     data class X509SanDns(val clientId: OriginalClientId, val chain: List<X509Certificate>) : AuthenticatedClient
     data class X509Hash(val clientId: OriginalClientId, val chain: List<X509Certificate>) : AuthenticatedClient
+    data class Origin(val clientId: OriginalClientId) : AuthenticatedClient
 }
 
 internal data class AuthenticatedRequest(
@@ -70,13 +77,31 @@ internal class RequestAuthenticator(openId4VPConfig: OpenId4VPConfig, httpClient
     private val clientAuthenticator = ClientAuthenticator(openId4VPConfig)
     private val signatureVerifier = JarJwtSignatureVerifier(openId4VPConfig, httpClient)
 
-    suspend fun authenticate(request: ReceivedRequest): AuthenticatedRequest = coroutineScope {
-        val client = clientAuthenticator.authenticateClient(request)
+    suspend fun authenticateRequestOverDCApi(origin: String, request: ReceivedRequest): AuthenticatedRequest = coroutineScope {
+        val (client, signedJwt) = clientAuthenticator.authenticateClientOverDCApi(origin, request)
         when (request) {
             is ReceivedRequest.Unsigned -> {
                 AuthenticatedRequest(client, request.requestObject)
             }
 
+            is ReceivedRequest.Signed -> {
+                requireNotNull(signedJwt) {
+                    "Expected a signed request but was not."
+                }
+                val requestObject = signedJwt.requestObject()
+                    .extendWithHeaderAttributes(signedJwt.header)
+                with(signatureVerifier) { verifySignature(client, signedJwt) }
+                AuthenticatedRequest(client, requestObject)
+            }
+        }
+    }
+
+    suspend fun authenticateRequestOverHttp(request: ReceivedRequest): AuthenticatedRequest = coroutineScope {
+        val client = clientAuthenticator.authenticateClientOverHttp(request)
+        when (request) {
+            is ReceivedRequest.Unsigned -> {
+                AuthenticatedRequest(client, request.requestObject)
+            }
             is ReceivedRequest.Signed -> {
                 val signedJwt = request.ensureSingleSignedRequest()
                 with(signatureVerifier) { verifySignature(client, signedJwt) }
@@ -87,91 +112,173 @@ internal class RequestAuthenticator(openId4VPConfig: OpenId4VPConfig, httpClient
 }
 
 internal class ClientAuthenticator(private val openId4VPConfig: OpenId4VPConfig) {
-    suspend fun authenticateClient(request: ReceivedRequest): AuthenticatedClient {
-        val requestObject = when (request) {
-            is ReceivedRequest.Signed -> {
-                request.ensureSingleSignedRequest().requestObject()
-            }
-            is ReceivedRequest.Unsigned -> request.requestObject
-        }
 
-        val (originalClientId, clientIdPrefix) = originalClientIdAndPrefix(requestObject)
-        return when (clientIdPrefix) {
-            is Preregistered -> {
-                val registeredClient = clientIdPrefix.clients[originalClientId]
-                ensureNotNull(registeredClient) { RequestValidationError.InvalidClientId.asException() }
-                if (request is ReceivedRequest.Signed) {
-                    ensureNotNull(registeredClient.jarConfig) {
-                        invalidPrefix("$registeredClient cannot place signed request")
+    /**
+     * In case of DC API channel client_id is present per case:
+     * - When request is unsinged is not included in request and is implied to be 'origin:<origin as passed from DC API call>'
+     * - When request is a JWS in compact serialization client_id is expected to exist in claims
+     * - When request is a JWS in JSON serialization client_id must exist in the header of each signature
+     */
+    suspend fun authenticateClientOverDCApi(origin: String, request: ReceivedRequest): Pair<AuthenticatedClient, SignedJWT?> =
+        when (request) {
+            is ReceivedRequest.Unsigned -> Origin(origin) to null
+
+            is ReceivedRequest.Signed -> {
+                val jwsJson = request.jwsJson
+                when (jwsJson) {
+                    is JwsJson.Flattened -> {
+                        val signedJwt = jwsJson.toSignedJwt()
+                        val (originalClientId, clientIdPrefix) = originalClientIdAndPrefix(signedJwt.requestObject())
+                        authenticateClientPrefix(originalClientId, clientIdPrefix, signedJwt) to signedJwt
+                    }
+
+                    is JwsJson.General -> {
+                        val policy = openId4VPConfig.signedRequestConfiguration.multiSignedRequestsPolicy
+                        val (originalClientId, clientIdPrefix, signedJwt) = jwsJson apply policy
+                        authenticateClientPrefix(originalClientId, clientIdPrefix, signedJwt) to signedJwt
                     }
                 }
-                AuthenticatedClient.Preregistered(registeredClient)
+            }
+        }
+
+    private infix fun JwsJson.General.apply(
+        policy: MultiSignedRequestsPolicy,
+    ): Triple<OriginalClientId, SupportedClientIdPrefix, SignedJWT> =
+        when (policy) {
+            is MultiSignedRequestsPolicy.Expect ->
+                matchExpectedClientPrefix(policy.clientPrefix)
+
+            MultiSignedRequestsPolicy.NotSupported ->
+                throw RequestValidationError.MultiSignedRequestsNotSupported.asException()
+        }
+
+    /**
+     * In case of HTTP channel client_id is mandatory to always exist.
+     */
+    suspend fun authenticateClientOverHttp(request: ReceivedRequest): AuthenticatedClient {
+        val (signedRequest, requestObject) = when (request) {
+            is ReceivedRequest.Unsigned -> null to request.requestObject
+            is ReceivedRequest.Signed -> {
+                val signedRequest = request.ensureSingleSignedRequest()
+                signedRequest to signedRequest.requestObject()
+            }
+        }
+        val (originalClientId, clientIdPrefix) = originalClientIdAndPrefix(requestObject)
+        return authenticateClientPrefix(originalClientId, clientIdPrefix, signedRequest)
+    }
+
+    private fun JwsJson.General.matchExpectedClientPrefix(
+        expectedPrefix: ClientIdPrefix,
+    ): Triple<OriginalClientId, SupportedClientIdPrefix, SignedJWT> =
+        flatten().map { flattened ->
+            flattened.clientIdFromProtectedHeader()?.let { clientId ->
+                val verifierId = VerifierId.parse(clientId).getOrElse {
+                    throw invalidPrefix("Invalid client_id: ${it.message}")
+                }
+                if (verifierId.prefix == expectedPrefix) {
+                    val supportedClientIdPrefix = openId4VPConfig.supportedClientIdPrefix(verifierId.prefix)
+                    ensureNotNull(supportedClientIdPrefix) { RequestValidationError.UnsupportedClientIdPrefix.asException() }
+                    Triple(verifierId.originalClientId, supportedClientIdPrefix, flattened.toSignedJwt())
+                } else
+                    null
+            }
+        }.firstOrNull()
+            ?: throw NoMatchingClientPrefixInMultiSignedRequest.asException()
+
+    private fun JwsJson.Flattened.assertVerifierInProtectedHeader() {
+        // If verifier_info exists in unprotected header cannot be trusted
+        // if verifier_info exists in unprotected header but not in protected fail
+    }
+
+    private fun JwsJson.Flattened.clientIdFromProtectedHeader(): String? {
+        val protectedHeader: JsonObject? = protected?.decodeAs()
+        return protectedHeader?.get("client_id")?.let {
+            ensure(it is JsonPrimitive) { error("Invalid client_id") }
+            it.content
+        }
+    }
+
+    private suspend fun authenticateClientPrefix(
+        originalClientId: OriginalClientId,
+        clientIdPrefix: SupportedClientIdPrefix,
+        signedRequest: SignedJWT?,
+    ): AuthenticatedClient = when (clientIdPrefix) {
+        is Preregistered -> {
+            val registeredClient = clientIdPrefix.clients[originalClientId]
+            ensureNotNull(registeredClient) { RequestValidationError.InvalidClientId.asException() }
+            signedRequest?.let {
+                ensureNotNull(registeredClient.jarConfig) {
+                    invalidPrefix("$registeredClient cannot place signed request")
+                }
+            }
+            AuthenticatedClient.Preregistered(registeredClient)
+        }
+
+        SupportedClientIdPrefix.RedirectUri -> {
+            ensure(signedRequest == null) {
+                invalidPrefix("${clientIdPrefix.prefix()} cannot be used in signed request")
+            }
+            val originalClientIdAsUri =
+                originalClientId.asHttpsURI { RequestValidationError.InvalidClientId.asException() }.getOrThrow()
+            RedirectUri(originalClientIdAsUri)
+        }
+
+        is SupportedClientIdPrefix.X509SanDns -> {
+            ensure(signedRequest != null) {
+                invalidPrefix("${clientIdPrefix.prefix()} cannot be used in unsigned request")
+            }
+            val chain = x5c(signedRequest, clientIdPrefix.trust)
+
+            val alternativeNames = chain.first().sanOfDNSName().getOrNull()
+            ensureNotNull(alternativeNames) { invalidJarJwt("Certificates misses DNS names") }
+            ensure(originalClientId in alternativeNames) {
+                invalidJarJwt("ClientId not found in certificate's subject alternative names")
             }
 
-            SupportedClientIdPrefix.RedirectUri -> {
-                ensure(request is ReceivedRequest.Unsigned) {
-                    invalidPrefix("${clientIdPrefix.prefix()} cannot be used in signed request")
-                }
-                val originalClientIdAsUri =
-                    originalClientId.asHttpsURI { RequestValidationError.InvalidClientId.asException() }.getOrThrow()
-                AuthenticatedClient.RedirectUri(originalClientIdAsUri)
+            X509SanDns(originalClientId, chain)
+        }
+
+        is SupportedClientIdPrefix.DecentralizedIdentifier -> {
+            ensure(signedRequest != null) {
+                invalidPrefix("${clientIdPrefix.prefix()} cannot be used in unsigned request")
+            }
+            val originalClientIdAsDID = ensureNotNull(DID.parse(originalClientId).getOrNull()) {
+                RequestValidationError.InvalidClientId.asException()
+            }
+            val clientPubKey = lookupKeyByDID(signedRequest, originalClientIdAsDID, clientIdPrefix.lookup)
+            DecentralizedIdentifier(originalClientIdAsDID, clientPubKey)
+        }
+
+        is SupportedClientIdPrefix.VerifierAttestation -> {
+            ensure(signedRequest != null) {
+                invalidPrefix("${clientIdPrefix.prefix()} cannot be used in unsigned request")
+            }
+            val attestedClaims =
+                verifierAttestation(openId4VPConfig.clock, clientIdPrefix, signedRequest, originalClientId)
+            VerifierAttestation(originalClientId, attestedClaims)
+        }
+
+        is SupportedClientIdPrefix.X509Hash -> {
+            ensure(signedRequest != null) {
+                invalidPrefix("${clientIdPrefix.prefix()} cannot be used in unsigned request")
+            }
+            val chain = x5c(signedRequest, clientIdPrefix.trust)
+
+            val expectedHash = base64UrlNoPadding.encode(
+                MessageDigest.getInstance("SHA-256").digest(chain.first().encoded),
+            )
+            ensure(expectedHash == originalClientId) {
+                invalidJarJwt("ClientId does not match leaf certificate's SHA-256 hash")
             }
 
-            is SupportedClientIdPrefix.DecentralizedIdentifier -> {
-                ensure(request is ReceivedRequest.Signed) {
-                    invalidPrefix("${clientIdPrefix.prefix()} cannot be used in unsigned request")
-                }
-                val originalClientIdAsDID = ensureNotNull(DID.parse(originalClientId).getOrNull()) {
-                    RequestValidationError.InvalidClientId.asException()
-                }
-                val clientPubKey = lookupKeyByDID(request, originalClientIdAsDID, clientIdPrefix.lookup)
-                AuthenticatedClient.DecentralizedIdentifier(originalClientIdAsDID, clientPubKey)
-            }
-
-            is SupportedClientIdPrefix.VerifierAttestation -> {
-                ensure(request is ReceivedRequest.Signed) {
-                    invalidPrefix("${clientIdPrefix.prefix()} cannot be used in unsigned request")
-                }
-                val attestedClaims =
-                    verifierAttestation(openId4VPConfig.clock, clientIdPrefix, request, originalClientId)
-                AuthenticatedClient.VerifierAttestation(originalClientId, attestedClaims)
-            }
-
-            is SupportedClientIdPrefix.X509SanDns -> {
-                ensure(request is ReceivedRequest.Signed) {
-                    invalidPrefix("${clientIdPrefix.prefix()} cannot be used in unsigned request")
-                }
-                val chain = x5c(request, clientIdPrefix.trust)
-
-                val alternativeNames = chain.first().sanOfDNSName().getOrNull()
-                ensureNotNull(alternativeNames) { invalidJarJwt("Certificates misses DNS names") }
-                ensure(originalClientId in alternativeNames) {
-                    invalidJarJwt("ClientId not found in certificate's subject alternative names")
-                }
-
-                AuthenticatedClient.X509SanDns(originalClientId, chain)
-            }
-
-            is SupportedClientIdPrefix.X509Hash -> {
-                ensure(request is ReceivedRequest.Signed) {
-                    invalidPrefix("${clientIdPrefix.prefix()} cannot be used in unsigned request")
-                }
-                val chain = x5c(request, clientIdPrefix.trust)
-
-                val expectedHash = base64UrlNoPadding.encode(
-                    MessageDigest.getInstance("SHA-256").digest(chain.first().encoded),
-                )
-                ensure(expectedHash == originalClientId) {
-                    invalidJarJwt("ClientId does not match leaf certificate's SHA-256 hash")
-                }
-
-                AuthenticatedClient.X509Hash(originalClientId, chain)
-            }
+            X509Hash(originalClientId, chain)
         }
     }
 
     private fun originalClientIdAndPrefix(requestObject: UnvalidatedRequestObject): Pair<OriginalClientId, SupportedClientIdPrefix> {
-        val clientId = ensureNotNull(requestObject.clientId) { RequestValidationError.MissingClientId.asException() }
+        val clientId = ensureNotNull(requestObject.clientId) {
+            RequestValidationError.MissingClientId.asException()
+        }
         val verifierId =
             VerifierId.parse(clientId).getOrElse { throw invalidPrefix("Invalid client_id: ${it.message}") }
         val supportedClientIdPrefix = openId4VPConfig.supportedClientIdPrefix(verifierId.prefix)
@@ -180,11 +287,10 @@ internal class ClientAuthenticator(private val openId4VPConfig: OpenId4VPConfig)
     }
 
     private fun x5c(
-        request: ReceivedRequest.Signed,
+        requestJwt: SignedJWT,
         trust: X509CertificateTrust,
     ): List<X509Certificate> {
-        val jwt = request.ensureSingleSignedRequest()
-        val x5c = jwt.header?.x509CertChain
+        val x5c = requestJwt.header?.x509CertChain
         ensureNotNull(x5c) { invalidJarJwt("Missing x5c") }
         val pubCertChain = x5c.mapNotNull { runCatchingCancellable { X509CertUtils.parse(it.decode()) }.getOrNull() }
         ensure(pubCertChain.isNotEmpty()) { invalidJarJwt("Invalid x5c") }
@@ -193,21 +299,18 @@ internal class ClientAuthenticator(private val openId4VPConfig: OpenId4VPConfig)
     }
 }
 
-private fun ReceivedRequest.Signed.ensureSingleSignedRequest(): SignedJWT {
-    val signedJwts = toSignedJwts()
-    return ensure(signedJwts.size == 1) {
-        invalidJarJwt("Multi-signed authorization requests are not yet supported")
-    }.let { signedJwts[0] }
-}
+private fun ReceivedRequest.Signed.ensureSingleSignedRequest(): SignedJWT =
+    ensure(jwsJson is JwsJson.Flattened) {
+        invalidJarJwt("Multi-signed authorization requests is not expected.")
+    }.let { jwsJson.toSignedJwt() }
 
 private suspend fun lookupKeyByDID(
-    request: ReceivedRequest.Signed,
+    signedRequest: SignedJWT,
     clientId: DID,
     lookupPublicKeyByDIDUrl: LookupPublicKeyByDIDUrl,
 ): PublicKey = withContext(Dispatchers.IO) {
     val keyUrl: AbsoluteDIDUrl = run {
-        val jwt = request.ensureSingleSignedRequest()
-        val kid = ensureNotNull(jwt.header?.keyID) {
+        val kid = ensureNotNull(signedRequest.header?.keyID) {
             invalidJarJwt("Missing kid for client_id $clientId")
         }
         ensureNotNull(AbsoluteDIDUrl.parse(kid).getOrNull()) {
@@ -226,7 +329,7 @@ private suspend fun lookupKeyByDID(
 private fun verifierAttestation(
     clock: Clock,
     supportedPrefix: SupportedClientIdPrefix.VerifierAttestation,
-    request: ReceivedRequest.Signed,
+    signedRequest: SignedJWT,
     originalClientId: OriginalClientId,
 ): VerifierAttestationClaims {
     val (trust, skew) = supportedPrefix
@@ -234,8 +337,7 @@ private fun verifierAttestation(
         invalidJarJwt("Invalid VerifierAttestation JWT. Details: $cause")
 
     val verifierAttestationJwt = run {
-        val jwt = request.ensureSingleSignedRequest()
-        val jwtString = jwt.header.customParams["jwt"]
+        val jwtString = signedRequest.header.customParams["jwt"]
         ensureNotNull(jwtString) { invalidJarJwt("Missing jwt JOSE Header") }
         ensure(jwtString is String) { invalidJarJwt("jwt JOSE Header doesn't contain a JWT") }
 
@@ -311,6 +413,9 @@ private class JarJwtSignatureVerifier(
 
             is AuthenticatedClient.X509Hash ->
                 JWSKeySelector<SecurityContext> { _, _ -> listOf(client.chain[0].publicKey) }
+
+            is AuthenticatedClient.Origin ->
+                throw RequestValidationError.UnsupportedClientIdPrefix.asException()
         }
 
     @Throws(AuthorizationRequestException::class)
@@ -347,6 +452,14 @@ private fun invalidJarJwt(cause: String): AuthorizationRequestException =
 
 internal fun SignedJWT.requestObject(): UnvalidatedRequestObject =
     jsonSupport.decodeFromString(JSONObjectUtils.toJSONString(jwtClaimsSet.toJSONObject()))
+
+private fun UnvalidatedRequestObject.extendWithHeaderAttributes(header: JWSHeader?): UnvalidatedRequestObject =
+    header?.getCustomParam(OpenId4VPSpec.VERIFIER_INFO)
+        ?.let { verifierInfo ->
+            ensure(verifierInfo is JsonObject) { error("Invalid verifier_info. Expected JsonObject but was ${verifierInfo::class}") }
+            val verifierInfo = jsonSupport.decodeFromString<VerifierInfoTO>(JSONObjectUtils.toJSONString(verifierInfo))
+            this.copy(verifierInfo = verifierInfo)
+        } ?: this
 
 internal data class VerifierAttestationClaims(
     val iss: String,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticator.kt
@@ -87,16 +87,13 @@ internal class RequestAuthenticator(openId4VPConfig: OpenId4VPConfig, httpClient
                 requireNotNull(signedJwt) {
                     "Expected a signed request but was not."
                 }
-                val requestObject = when (request) {
-                    is ReceivedRequest.Signed ->
-                        signedJwt.requestObject()
-                    is ReceivedRequest.MultiSigned ->
-                        signedJwt.requestObject()
-                            .extendWithHeaderAttributes(signedJwt.header)
-                    else -> error("Cannot happen")
-                }
                 with(signatureVerifier) {
                     verifySignature(client, signedJwt)
+                }
+                val requestObject = when (request) {
+                    is ReceivedRequest.Signed -> signedJwt.requestObject()
+                    is ReceivedRequest.MultiSigned -> signedJwt.requestObject().extendWithHeaderAttributes(signedJwt.header)
+                    else -> error("Cannot happen")
                 }
                 AuthenticatedRequest(client, requestObject)
             }
@@ -193,7 +190,7 @@ internal class ClientAuthenticator(private val openId4VPConfig: OpenId4VPConfig)
             ?: throw NoMatchingClientPrefixInMultiSignedRequest.asException()
 
     private fun JwsJson.Flattened.clientIdFromProtectedHeader(): String? {
-        val protectedHeader: JsonObject? = protected?.decodeAs()
+        val protectedHeader = protected?.decodeAs<JsonObject>()
         return protectedHeader?.get("client_id")?.let {
             ensure(it is JsonPrimitive) { error("Invalid client_id") }
             it.content
@@ -453,7 +450,9 @@ internal fun SignedJWT.requestObject(): UnvalidatedRequestObject =
 private fun UnvalidatedRequestObject.extendWithHeaderAttributes(header: JWSHeader?): UnvalidatedRequestObject =
     header?.getCustomParam(OpenId4VPSpec.VERIFIER_INFO)
         ?.let { verifierInfo ->
-            ensure(verifierInfo is JsonObject) { error("Invalid verifier_info. Expected JsonObject but was ${verifierInfo::class}") }
+            ensure(verifierInfo is JsonObject) {
+                error("Invalid verifier_info. Expected JsonObject but was ${verifierInfo::class}")
+            }
             val verifierInfo = jsonSupport.decodeFromString<VerifierInfoTO>(JSONObjectUtils.toJSONString(verifierInfo))
             this.copy(verifierInfo = verifierInfo)
         } ?: this

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcher.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcher.kt
@@ -64,7 +64,7 @@ internal class RequestFetcher(
         val (_, requestUri, requestUriMethod) = request
 
         val supportedMethods =
-            openId4VPConfig.jarConfiguration.supportedRequestUriMethods
+            openId4VPConfig.signedRequestConfiguration.supportedRequestUriMethods
         val postOptions = supportedMethods.isPostSupported()
 
         suspend fun useGET(): Pair<Jwt, Nonce?> {
@@ -138,7 +138,7 @@ private fun OpenId4VPConfig.ensureSupportedSigningAlgorithm(signedJwt: SignedJWT
     val signingAlg = ensureNotNull(signedJwt.header.algorithm) {
         invalidJwt("JAR is missing alg claim from header")
     }
-    ensure(signingAlg in jarConfiguration.supportedAlgorithms) {
+    ensure(signingAlg in signedRequestConfiguration.supportedAlgorithms) {
         invalidJwt("JAR is signed with ${signingAlg.name} which is not supported")
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectValidator.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestObjectValidator.kt
@@ -28,6 +28,34 @@ import java.net.URL
 
 internal class RequestObjectValidator(private val openId4VPConfig: OpenId4VPConfig) {
 
+    fun validateDCApiRequestObject(origin: String, request: AuthenticatedRequest, isSigned: Boolean): ResolvedRequestObject {
+        val (client, requestObject) = request
+        val state = requestObject.state
+        val nonce = requiredNonce(requestObject)
+        val scope = requiredScope(requestObject)
+        val nonOpenIdScope = with(Scope) { scope.getOrNull()?.items()?.filter { it != OpenId }?.mergeOrNull() }
+        val query = requiredDcqlQuery(requestObject, nonOpenIdScope, openId4VPConfig.vpConfiguration.vpFormatsSupported)
+        val responseMode = requiredResponseModeOverDCApi(requestObject)
+        val clientMetaData = optionalClientMetaData(responseMode, query, requestObject)
+        val transactionData = optionalTransactionData(requestObject, query)
+        val verifierInfo = optionalVerifierInfo(query, requestObject)
+        if (isSigned) {
+            requireExpectedOrigins(origin, requestObject)
+        }
+
+        return ResolvedRequestObject(
+            client = client.toClient(),
+            responseMode = responseMode,
+            state = state,
+            nonce = nonce,
+            responseEncryptionSpecification = clientMetaData?.responseEncryptionSpecification,
+            vpFormatsSupported = clientMetaData?.vpFormatsSupported,
+            query = query,
+            transactionData = transactionData,
+            verifierInfo = verifierInfo,
+        )
+    }
+
     /**
      * Validates that the given [request] represents a valid [ResolvedRequestObject].
      *
@@ -37,7 +65,7 @@ internal class RequestObjectValidator(private val openId4VPConfig: OpenId4VPConf
      * raises an AuthorizationRequestException. Validation rules violations are reported using [AuthorizationRequestError]
      * wrapped inside the [specific exception][AuthorizationRequestException]
      */
-    fun validateRequestObject(request: AuthenticatedRequest): ResolvedRequestObject {
+    fun validateHttpRequestObject(request: AuthenticatedRequest): ResolvedRequestObject {
         val (client, requestObject) = request
 
         ensureVpTokenResponseType(requestObject)
@@ -45,7 +73,7 @@ internal class RequestObjectValidator(private val openId4VPConfig: OpenId4VPConf
         val nonOpenIdScope = with(Scope) { scope.getOrNull()?.items()?.filter { it != OpenId }?.mergeOrNull() }
         val state = requestObject.state
         val nonce = requiredNonce(requestObject)
-        val responseMode = requiredResponseMode(client, requestObject)
+        val responseMode = requiredResponseModeOverHttp(client, requestObject)
         val query = requiredDcqlQuery(requestObject, nonOpenIdScope, openId4VPConfig.vpConfiguration.vpFormatsSupported)
         val transactionData = optionalTransactionData(requestObject, query)
         val verifierInfo = optionalVerifierInfo(query, requestObject)
@@ -156,7 +184,7 @@ internal class RequestObjectValidator(private val openId4VPConfig: OpenId4VPConf
         return verifierInfo
     }
 
-    private fun requiredResponseMode(
+    private fun requiredResponseModeOverHttp(
         client: AuthenticatedClient,
         unvalidated: UnvalidatedRequestObject,
     ): ResponseMode {
@@ -212,6 +240,10 @@ internal class RequestObjectValidator(private val openId4VPConfig: OpenId4VPConf
                     is ResponseMode.FragmentJwt,
                     -> client.claims.redirectUris
 
+                    ResponseMode.DCApi,
+                    ResponseMode.DCApiJwt,
+                    -> error("Unsupported response mode $responseMode")
+
                     is ResponseMode.DirectPost,
                     is ResponseMode.DirectPostJwt,
                     -> client.claims.responseUris
@@ -228,8 +260,20 @@ internal class RequestObjectValidator(private val openId4VPConfig: OpenId4VPConf
             }
 
             is AuthenticatedClient.X509Hash -> Unit
+
+            is AuthenticatedClient.Origin ->
+                throw IllegalStateException("Origin client is not supported for response_mode: $responseMode")
         }
 
+        return responseMode
+    }
+
+    private fun requiredResponseModeOverDCApi(unvalidated: UnvalidatedRequestObject): ResponseMode {
+        val responseMode = when (unvalidated.responseMode) {
+            "dc_api" -> ResponseMode.DCApi
+            "dc_api.jwt" -> ResponseMode.DCApiJwt
+            else -> throw UnsupportedResponseMode(unvalidated.responseMode).asException()
+        }
         return responseMode
     }
 
@@ -302,6 +346,18 @@ internal class RequestObjectValidator(private val openId4VPConfig: OpenId4VPConf
             }
         }
     }
+
+    private fun requireExpectedOrigins(
+        origin: String,
+        requestObject: UnvalidatedRequestObject,
+    ) {
+        ensure(requestObject.expectedOrigins != null) {
+            MissingExpectedOrigins.asException()
+        }
+        ensure(origin in requestObject.expectedOrigins) {
+            UnexpectedOrigin.asException()
+        }
+    }
 }
 
 private fun AuthenticatedClient.toClient(): Client =
@@ -316,6 +372,7 @@ private fun AuthenticatedClient.toClient(): Client =
         is AuthenticatedClient.VerifierAttestation -> Client.VerifierAttestation(clientId)
         is AuthenticatedClient.X509SanDns -> Client.X509SanDns(clientId, chain[0])
         is AuthenticatedClient.X509Hash -> Client.X509Hash(clientId, chain[0])
+        is AuthenticatedClient.Origin -> Client.Origin(clientId)
     }
 
 private fun ResponseMode.uri(): URI = when (this) {
@@ -325,6 +382,9 @@ private fun ResponseMode.uri(): URI = when (this) {
     is ResponseMode.FragmentJwt -> redirectUri
     is ResponseMode.Query -> redirectUri
     is ResponseMode.QueryJwt -> redirectUri
+    ResponseMode.DCApi,
+    ResponseMode.DCApiJwt,
+    -> error("No uri for response mode $this")
 }
 
 private fun TransactionData.ensureSupported(supportedTransactionDataTypes: List<SupportedTransactionDataType>) =

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
@@ -50,12 +50,12 @@ internal fun walletMetaData(cfg: OpenId4VPConfig, clientId: String, keys: List<J
             VerifierId.parse(clientId).getOrNull()?.prefix?.permitsSignedRequestObjects() ?: false
         if (permitsSignedRequestObjects) {
             putJsonArray(REQUEST_OBJECT_SIGNING_ALG_VALUES_SUPPORTED) {
-                cfg.jarConfiguration.supportedAlgorithms.forEach { alg -> add(alg.name) }
+                cfg.signedRequestConfiguration.supportedAlgorithms.forEach { alg -> add(alg.name) }
             }
         }
 
         // Encryption
-        cfg.jarConfiguration.supportedRequestUriMethods.isPostSupported()?.let { requestUriMethodPost ->
+        cfg.signedRequestConfiguration.supportedRequestUriMethods.isPostSupported()?.let { requestUriMethodPost ->
             val jarEncryption = requestUriMethodPost.jarEncryption
             if (jarEncryption is EncryptionRequirement.Required && keys.isNotEmpty()) {
                 put(JWKS, JWKSet(keys).toJSONObject(true).toJsonObject())
@@ -109,4 +109,5 @@ internal val ClientIdPrefix.metadataValue: String
         VerifierAttestation -> OpenId4VPSpec.CLIENT_ID_PREFIX_VERIFIER_ATTESTATION
         X509SanDns -> OpenId4VPSpec.CLIENT_ID_PREFIX_X509_SAN_DNS
         X509Hash -> OpenId4VPSpec.CLIENT_ID_PREFIX_X509_HASH
+        ORIGIN -> OpenId4VPSpec.CLIENT_ID_PREFIX_ORIGIN
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationRequestErrorCode.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationRequestErrorCode.kt
@@ -132,6 +132,12 @@ internal enum class AuthorizationRequestErrorCode(val code: String) {
                 is InvalidVerifierInfo,
                 MissingClientMetadataJwks,
                 is ClientMetadataJwksUnparsable,
+                MissingExpectedOrigins,
+                MultiSignedRequestsNotSupported,
+                NoMatchingClientPrefixInMultiSignedRequest,
+                UnexpectedOrigin,
+                UnsupportedDcApiExchangeProtocol,
+                is DcApiExchangeProtocolNotMatchesReceivedRequest,
                 -> INVALID_REQUEST
 
                 InvalidClientId, UnsupportedClientIdPrefix -> INVALID_CLIENT

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponse.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponse.kt
@@ -16,6 +16,11 @@
 package eu.europa.ec.eudi.openid4vp.internal.response
 
 import eu.europa.ec.eudi.openid4vp.*
+import eu.europa.ec.eudi.openid4vp.internal.response.AuthorizationResponse.DCApi
+import eu.europa.ec.eudi.openid4vp.internal.response.AuthorizationResponse.DCApiJwt
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import java.net.URI
 import java.net.URL
 
@@ -71,6 +76,69 @@ internal sealed interface AuthorizationResponsePayload : java.io.Serializable {
         override val encryptionParameters: EncryptionParameters? = null,
     ) : Failed
 }
+
+private const val VP_TOKEN_FORM_PARAM = "vp_token"
+
+/**
+ * Converts the [AuthorizationResponsePayload] into a map structure suitable for dispatching.
+ *
+ * The output map contains key-value pairs representing the payload's details.
+ * Different types of [AuthorizationResponsePayload] are handled specifically:
+ * - [eu.europa.ec.eudi.openid4vp.internal.response.AuthorizationResponsePayload.Success] adds Verifiable Presentation details and optionally `state`.
+ * - [eu.europa.ec.eudi.openid4vp.internal.response.AuthorizationResponsePayload.InvalidRequest] adds error-related details and optionally `state`.
+ * - [eu.europa.ec.eudi.openid4vp.internal.response.AuthorizationResponsePayload.NoConsensusResponseData] adds an access-denied error code and optionally `state`.
+ *
+ * @return A map containing the serialized details of the authorization response payload.
+ */
+internal fun AuthorizationResponsePayload.asDispatchingMap(): Map<String, String> =
+    when (this) {
+        is AuthorizationResponsePayload.Success -> buildMap {
+            put(VP_TOKEN_FORM_PARAM, verifiablePresentations.asParam())
+            state?.let {
+                put(OpenId4VPSpec.STATE, it)
+            }
+        }
+
+        is AuthorizationResponsePayload.InvalidRequest -> buildMap {
+            put(OpenId4VPSpec.ERROR, AuthorizationRequestErrorCode.fromError(error).code)
+            put(OpenId4VPSpec.ERROR_DESCRIPTION, "$error")
+            state?.let {
+                put(OpenId4VPSpec.STATE, it)
+            }
+        }
+
+        is AuthorizationResponsePayload.NoConsensusResponseData -> buildMap {
+            put(OpenId4VPSpec.ERROR, AuthorizationRequestErrorCode.ACCESS_DENIED.code)
+            state?.let {
+                put(OpenId4VPSpec.STATE, it)
+            }
+        }
+    }
+
+internal fun AuthorizationResponsePayload.asJsonObject(): JsonObject =
+    when (this) {
+        is AuthorizationResponsePayload.Success -> buildJsonObject {
+            put(VP_TOKEN_FORM_PARAM, verifiablePresentations.asJsonObject())
+            state?.let {
+                put(OpenId4VPSpec.STATE, JsonPrimitive(it))
+            }
+        }
+
+        is AuthorizationResponsePayload.InvalidRequest -> buildJsonObject {
+            put(OpenId4VPSpec.ERROR, JsonPrimitive(AuthorizationRequestErrorCode.fromError(error).code))
+            put(OpenId4VPSpec.ERROR_DESCRIPTION, JsonPrimitive("$error"))
+            state?.let {
+                put(OpenId4VPSpec.STATE, JsonPrimitive(it))
+            }
+        }
+
+        is AuthorizationResponsePayload.NoConsensusResponseData -> buildJsonObject {
+            put(OpenId4VPSpec.ERROR, JsonPrimitive(AuthorizationRequestErrorCode.ACCESS_DENIED.code))
+            state?.let {
+                put(OpenId4VPSpec.STATE, JsonPrimitive(it))
+            }
+        }
+    }
 
 /**
  * An OAUTH2 authorization response
@@ -166,6 +234,21 @@ internal sealed interface AuthorizationResponse : java.io.Serializable {
             }
         }
     }
+
+    data class DCApi(
+        val data: AuthorizationResponsePayload,
+    ) : AuthorizationResponse
+
+    data class DCApiJwt(
+        val data: AuthorizationResponsePayload,
+        val responseEncryptionSpecification: ResponseEncryptionSpecification?,
+    ) : AuthorizationResponse {
+        init {
+            if (data !is AuthorizationResponsePayload.InvalidRequest) {
+                requireNotNull(responseEncryptionSpecification)
+            }
+        }
+    }
 }
 
 internal fun ResolvedRequestObject.responseWith(
@@ -209,12 +292,24 @@ private fun ResolvedRequestObject.responseWith(
             data,
             checkNotNull(responseEncryptionSpecification),
         )
+
         is ResponseMode.Fragment -> AuthorizationResponse.Fragment(mode.redirectUri, data)
         is ResponseMode.FragmentJwt -> AuthorizationResponse.FragmentJwt(
             mode.redirectUri,
             data,
             checkNotNull(responseEncryptionSpecification),
         )
+
         is ResponseMode.Query -> AuthorizationResponse.Query(mode.redirectUri, data)
-        is ResponseMode.QueryJwt -> AuthorizationResponse.QueryJwt(mode.redirectUri, data, checkNotNull(responseEncryptionSpecification))
+        is ResponseMode.QueryJwt -> AuthorizationResponse.QueryJwt(
+            mode.redirectUri,
+            data,
+            checkNotNull(responseEncryptionSpecification),
+        )
+
+        ResponseMode.DCApi -> DCApi(data)
+        ResponseMode.DCApiJwt -> DCApiJwt(
+            data,
+            checkNotNull(responseEncryptionSpecification),
+        )
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherOverDCApi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherOverDCApi.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.openid4vp.internal.response
 
+import eu.europa.ec.eudi.openid4vp.AuthorizationRequestError
 import eu.europa.ec.eudi.openid4vp.Consensus
 import eu.europa.ec.eudi.openid4vp.DispatcherOverDCApi
 import eu.europa.ec.eudi.openid4vp.EncryptionParameters
@@ -45,7 +46,14 @@ internal class DefaultDispatcherOverDCApi : DispatcherOverDCApi {
         return doAssemble(response)
     }
 
-    internal fun doAssemble(response: AuthorizationResponse): JsonObject = when (response) {
+    override fun assembleErrorResponse(
+        error: AuthorizationRequestError,
+    ): JsonObject = buildJsonObject {
+        val errorCode = AuthorizationRequestErrorCode.fromError(error)
+        put("error", JsonPrimitive(errorCode.code))
+    }
+
+    private fun doAssemble(response: AuthorizationResponse): JsonObject = when (response) {
         is AuthorizationResponse.DCApi ->
             response.data.asJsonObject()
 
@@ -54,7 +62,6 @@ internal class DefaultDispatcherOverDCApi : DispatcherOverDCApi {
         }
         else ->
             error("Unsupported authorization response ${response::class::simpleName} for dispatching over DC API")
-
     }
 
     private fun AuthorizationResponse.DCApiJwt.encryptData(): Jwt {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherOverDCApi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherOverDCApi.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vp.internal.response
+
+import eu.europa.ec.eudi.openid4vp.Consensus
+import eu.europa.ec.eudi.openid4vp.DispatcherOverDCApi
+import eu.europa.ec.eudi.openid4vp.EncryptionParameters
+import eu.europa.ec.eudi.openid4vp.Jwt
+import eu.europa.ec.eudi.openid4vp.ResolvedRequestObject
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+/**
+ * Default implementation of [DispatcherOverDCApi]
+ */
+internal class DefaultDispatcherOverDCApi : DispatcherOverDCApi {
+
+    override suspend fun assembleResponse(
+        request: ResolvedRequestObject,
+        consensus: Consensus,
+        encryptionParameters: EncryptionParameters?,
+    ): JsonObject {
+        require(consensus is Consensus.NegativeConsensus || consensus is Consensus.PositiveConsensus) {
+            "Invalid consensus. Expected either negative consensus or PositiveConsensus.VPTokenConsensus. " +
+                "Actual consensus: ${consensus::class::simpleName}"
+        }
+        val response = request.responseWith(consensus, encryptionParameters)
+        require(response is AuthorizationResponse.DCApi || response is AuthorizationResponse.DCApiJwt) {
+            "Unsupported response mode: ${response::class.simpleName} for request coming from DC API channel"
+        }
+        return doAssemble(response)
+    }
+
+    internal fun doAssemble(response: AuthorizationResponse): JsonObject = when (response) {
+        is AuthorizationResponse.DCApi ->
+            response.data.asJsonObject()
+
+        is AuthorizationResponse.DCApiJwt -> buildJsonObject {
+            put("response", JsonPrimitive(response.encryptData()))
+        }
+        else ->
+            error("Unsupported authorization response ${response::class::simpleName} for dispatching over DC API")
+
+    }
+
+    private fun AuthorizationResponse.DCApiJwt.encryptData(): Jwt {
+        val responseEncryptionSpecification = responseEncryptionSpecification
+        requireNotNull(responseEncryptionSpecification) { "Response Encryption specification missing" }
+        return responseEncryptionSpecification.encrypt(data)
+    }
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherOverHttp.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherOverHttp.kt
@@ -28,11 +28,11 @@ import java.net.URI
 import java.net.URL
 
 /**
- * Default implementation of [Dispatcher]
+ * Default implementation of [DispatcherOverHttp]
  */
-internal class DefaultDispatcher(
+internal class DefaultDispatcherOverHttp(
     private val httpClient: HttpClient,
-) : Dispatcher, ErrorDispatcher {
+) : DispatcherOverHttp, ErrorDispatcher {
 
     override suspend fun post(
         request: ResolvedRequestObject,
@@ -183,40 +183,10 @@ internal fun FragmentJwt.encodeRedirectURI(): URI =
  */
 internal object DirectPostForm {
 
-    private const val VP_TOKEN_FORM_PARAM = "vp_token"
-    private const val STATE_FORM_PARAM = "state"
-    private const val ERROR_FORM_PARAM = "error"
-    private const val ERROR_DESCRIPTION_FORM_PARAM = "error_description"
-
     fun parametersOf(p: AuthorizationResponsePayload): Parameters =
-        of(p).let { form ->
+        p.asDispatchingMap().let { map ->
             parameters {
-                form.entries.forEach { (name, value) -> append(name, value) }
-            }
-        }
-
-    fun of(p: AuthorizationResponsePayload): Map<String, String> =
-        when (p) {
-            is AuthorizationResponsePayload.Success -> buildMap {
-                put(VP_TOKEN_FORM_PARAM, p.verifiablePresentations.asParam())
-                p.state?.let {
-                    put(STATE_FORM_PARAM, it)
-                }
-            }
-
-            is AuthorizationResponsePayload.InvalidRequest -> buildMap {
-                put(ERROR_FORM_PARAM, AuthorizationRequestErrorCode.fromError(p.error).code)
-                put(ERROR_DESCRIPTION_FORM_PARAM, "${p.error}")
-                p.state?.let {
-                    put(STATE_FORM_PARAM, it)
-                }
-            }
-
-            is AuthorizationResponsePayload.NoConsensusResponseData -> buildMap {
-                put(ERROR_FORM_PARAM, AuthorizationRequestErrorCode.ACCESS_DENIED.code)
-                p.state?.let {
-                    put(STATE_FORM_PARAM, it)
-                }
+                map.entries.forEach { (name, value) -> append(name, value) }
             }
         }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/ErrorResponse.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/ErrorResponse.kt
@@ -19,6 +19,7 @@ import eu.europa.ec.eudi.openid4vp.AuthorizationRequestError
 import eu.europa.ec.eudi.openid4vp.EncryptionParameters
 import eu.europa.ec.eudi.openid4vp.ErrorDispatchDetails
 import eu.europa.ec.eudi.openid4vp.ResponseMode
+import eu.europa.ec.eudi.openid4vp.internal.response.AuthorizationResponse.*
 
 internal fun AuthorizationRequestError.responseWith(
     di: ErrorDispatchDetails,
@@ -56,6 +57,11 @@ private fun responseWith(
         is ResponseMode.Query -> AuthorizationResponse.Query(mode.redirectUri, data)
         is ResponseMode.QueryJwt -> AuthorizationResponse.QueryJwt(
             mode.redirectUri,
+            data,
+            di.responseEncryptionSpecification,
+        )
+        ResponseMode.DCApi -> DCApi(data)
+        ResponseMode.DCApiJwt -> DCApiJwt(
             data,
             di.responseEncryptionSpecification,
         )

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/ErrorResponse.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/ErrorResponse.kt
@@ -60,9 +60,8 @@ private fun responseWith(
             data,
             di.responseEncryptionSpecification,
         )
-        ResponseMode.DCApi -> DCApi(data)
-        ResponseMode.DCApiJwt -> DCApiJwt(
-            data,
-            di.responseEncryptionSpecification,
-        )
+
+        ResponseMode.DCApi,
+        ResponseMode.DCApiJwt,
+        -> error("DC API response mode not supported for error dispatching via redirects")
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/ConfigTests.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/ConfigTests.kt
@@ -15,7 +15,9 @@
  */
 package eu.europa.ec.eudi.openid4vp
 
+import com.nimbusds.jose.JWSAlgorithm
 import org.junit.jupiter.api.assertDoesNotThrow
+import java.net.URI
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
@@ -49,6 +51,38 @@ class ConfigTests {
 
         assertFailsWith<IllegalArgumentException> {
             VpFormatsSupported(null, null)
+        }
+    }
+
+    @Test
+    fun `if jar config for multi-signed requests is MultiSignedRequestsPolicy_ExpectPrefix it must include a supported scheme`() {
+        val preRegSupportedPrefix = SupportedClientIdPrefix.Preregistered(
+            PreregisteredClient(
+                "Verifier",
+                "Verifier",
+                JWSAlgorithm.RS256 to JwkSetSource.ByReference(URI("http://localhost:8080/wallet/public-keys.json")),
+            ),
+        )
+        val x509SanDnsSupportedScheme = SupportedClientIdPrefix.X509SanDns({ _ -> true })
+
+        assertFailsWith<IllegalArgumentException> {
+            OpenId4VPConfig(
+                vpConfiguration = VPConfiguration(
+                    vpFormatsSupported = VpFormatsSupported(
+                        VpFormatsSupported.SdJwtVc.HAIP,
+                        VpFormatsSupported.MsoMdoc(
+                            issuerAuthAlgorithms = listOf(CoseAlgorithm(-7)),
+                            deviceAuthAlgorithms = listOf(CoseAlgorithm(-7)),
+                        ),
+                    ),
+                ),
+                supportedClientIdPrefixes = listOf(x509SanDnsSupportedScheme, preRegSupportedPrefix),
+                signedRequestConfiguration = SignedRequestConfiguration(
+                    supportedAlgorithms = JWSAlgorithm.Family.EC.toList() - JWSAlgorithm.ES256K,
+                    supportedRequestUriMethods = SupportedRequestUriMethods.Default,
+                    multiSignedRequestsPolicy = MultiSignedRequestsPolicy.Expect(ClientIdPrefix.DecentralizedIdentifier),
+                ),
+            )
         }
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
@@ -259,7 +259,7 @@ private class Wallet(
     private val httpClient: HttpClient,
 ) {
     private val openId4Vp: OpenId4Vp.OverHttp by lazy {
-        OpenId4Vp.overHttp(walletConfig, httpClient)
+        OpenId4Vp.overRedirects(walletConfig, httpClient)
     }
 
     suspend fun handle(uri: URI): DispatchOutcome {

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
@@ -258,8 +258,8 @@ private class Wallet(
     private val walletConfig: OpenId4VPConfig,
     private val httpClient: HttpClient,
 ) {
-    private val openId4Vp: OpenId4Vp by lazy {
-        OpenId4Vp(walletConfig, httpClient)
+    private val openId4Vp: OpenId4Vp.OverHttp by lazy {
+        OpenId4Vp.overHttp(walletConfig, httpClient)
     }
 
     suspend fun handle(uri: URI): DispatchOutcome {
@@ -271,7 +271,7 @@ private class Wallet(
         }
     }
 
-    suspend fun OpenId4Vp.handle(
+    suspend fun OpenId4Vp.OverHttp.handle(
         uri: String,
         holderConsensus: suspend (ResolvedRequestObject) -> Consensus,
     ): DispatchOutcome =
@@ -368,6 +368,7 @@ private class Wallet(
             is ResponseMode.FragmentJwt -> responseMode.redirectUri.toString()
             is ResponseMode.Query -> responseMode.redirectUri.toString()
             is ResponseMode.QueryJwt -> responseMode.redirectUri.toString()
+            ResponseMode.DCApi, ResponseMode.DCApiJwt -> error("No uri for response mode $this")
         }
 
         val openID4VPHandoverInfo = listOf(
@@ -456,7 +457,7 @@ private fun walletConfig(vararg supportedClientIdPrefix: SupportedClientIdPrefix
                 ),
             ),
         ),
-        jarConfiguration = JarConfiguration(
+        signedRequestConfiguration = SignedRequestConfiguration(
             supportedAlgorithms = JWSAlgorithm.Family.EC.toList() - JWSAlgorithm.ES256K,
             supportedRequestUriMethods = SupportedRequestUriMethods.Both(
                 SupportedRequestUriMethods.Post(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/MultiSignedRequests.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/MultiSignedRequests.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.openid4vp
+
+import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.factories.DefaultJWSSignerFactory
+import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jose.jwk.JWK
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import eu.europa.ec.eudi.openid4vp.internal.Base64UrlNoPadding
+import eu.europa.ec.eudi.openid4vp.internal.DID
+import eu.europa.ec.eudi.openid4vp.internal.JwsJson
+import eu.europa.ec.eudi.openid4vp.internal.Signature
+import eu.europa.ec.eudi.openid4vp.internal.base64UrlNoPadding
+import eu.europa.ec.eudi.openid4vp.internal.request.AttestationIssuer
+import eu.europa.ec.eudi.openid4vp.internal.request.ReceivedRequest
+import eu.europa.ec.eudi.openid4vp.internal.request.UnvalidatedRequestObject
+import kotlinx.serialization.json.Json
+import java.time.Clock
+
+internal fun UnvalidatedRequestObject.multiSigned(
+    signers: List<SchemeSigner>,
+): ReceivedRequest.MultiSigned {
+    require(signers.isNotEmpty()) { "At least one signer is required" }
+
+    // Convert the request object to JWT claims
+    val claimsSet = toJWTClaimSet()
+
+    // Create the payload as Base64UrlNoPadding
+    val payloadJson = claimsSet.toString()
+    val payloadBase64 = base64UrlNoPadding.encode(payloadJson.encodeToByteArray())
+    val payload = Base64UrlNoPadding.invoke(payloadBase64).getOrThrow()
+
+    // Create signatures for each signer
+    val signatures = signers.map { signer ->
+        // Create a SignedJWT for this signer
+        val header = with(JWSHeader.Builder(signer.alg)) {
+            type(JOSEObjectType(OpenId4VPSpec.AUTHORIZATION_REQUEST_OBJECT_TYPE))
+            signer.headerCustomization(this)
+            build()
+        }
+
+        // Sign the JWT
+        val jwt = SignedJWT(header, claimsSet).apply {
+            val jwsSigner = DefaultJWSSignerFactory().createJWSSigner(signer.key, signer.alg)
+            sign(jwsSigner)
+        }
+
+        // Extract the parts from the signed JWT
+        val parts = jwt.serialize().split(".")
+        val protectedHeader = Base64UrlNoPadding(parts[0]).getOrThrow()
+        val signature = Base64UrlNoPadding(parts[2]).getOrThrow()
+
+        // Create a Signature object
+        Signature(protected = protectedHeader, signature = signature)
+    }
+
+    // Create a JwsJson.General object with the payload and signatures
+    val jwsJson = JwsJson.General(payload = payload, signatures = signatures)
+
+    // Return a ReceivedRequest.Signed with the JwsJson.General object
+    return ReceivedRequest.MultiSigned(jwsJson)
+}
+
+class SchemeSigner(
+    val alg: JWSAlgorithm,
+    val key: JWK,
+    val headerCustomization: (JWSHeader.Builder).() -> Unit,
+)
+
+internal fun didSigner(didAlgAndKey: Pair<JWSAlgorithm, ECKey>): SchemeSigner {
+    val (alg2, key2) = didAlgAndKey
+    val originalClientId = DID.parse("did:example:123").getOrThrow()
+    val clientId = "decentralized_identifier:$originalClientId"
+    return SchemeSigner(alg2, key2) {
+        customParam("client_id", clientId)
+        keyID("did:example:123#key-1")
+    }
+}
+
+internal fun verifierAttestationSigner(didAlgAndKey: Pair<JWSAlgorithm, ECKey>, clock: Clock): SchemeSigner {
+    val (alg, key) = didAlgAndKey
+    val verifierAttestation = AttestationIssuer.attestation(
+        clock = clock,
+        clientId = "verifier_attestation:http://example.com",
+        clientPubKey = key.toPublicJWK(),
+    )
+    return SchemeSigner(alg, key) {
+        customParam("client_id", "verifier_attestation:http://www.example.com")
+        customParam("jwt", verifierAttestation.serialize())
+    }
+}
+
+internal fun UnvalidatedRequestObject.toJWTClaimSet(): JWTClaimsSet {
+    val json = Json.encodeToString(this)
+    return JWTClaimsSet.parse(json)
+}

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
@@ -29,11 +29,14 @@ import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.oauth2.sdk.id.State
+import eu.europa.ec.eudi.openid4vp.RequestValidationError.MissingExpectedOrigins
+import eu.europa.ec.eudi.openid4vp.RequestValidationError.UnexpectedOrigin
 import eu.europa.ec.eudi.openid4vp.dcql.DCQL
 import eu.europa.ec.eudi.openid4vp.dcql.QueryId
 import eu.europa.ec.eudi.openid4vp.internal.base64UrlNoPadding
 import eu.europa.ec.eudi.openid4vp.internal.jsonSupport
-import eu.europa.ec.eudi.openid4vp.internal.request.DefaultAuthorizationRequestResolver
+import eu.europa.ec.eudi.openid4vp.internal.request.DefaultRequestResolverOverDCApi
+import eu.europa.ec.eudi.openid4vp.internal.request.DefaultRequestResolverOverHttp
 import eu.europa.ec.eudi.openid4vp.internal.request.UnvalidatedClientMetaData
 import io.ktor.client.*
 import io.ktor.client.plugins.contentnegotiation.*
@@ -91,8 +94,7 @@ class UnvalidatedRequestResolverTest {
     fun teardown() {
         httpClient.close()
     }
-
-    private fun resolver() = DefaultAuthorizationRequestResolver(walletConfig, httpClient)
+    private fun resolver() = DefaultRequestResolverOverHttp(walletConfig, httpClient)
 
     private val dcqlQuery = readFileAsText("dcql/basic_example.json")
         .replace("\r\n", "")
@@ -152,7 +154,7 @@ class UnvalidatedRequestResolverTest {
             SupportedClientIdPrefix.X509SanDns(::validateChain),
             SupportedClientIdPrefix.X509Hash(::validateChain),
         ),
-        jarConfiguration = JarConfiguration(
+        signedRequestConfiguration = SignedRequestConfiguration(
             supportedAlgorithms = listOf(JWSAlgorithm.RS256),
         ),
         vpConfiguration = VPConfiguration(
@@ -211,7 +213,7 @@ class UnvalidatedRequestResolverTest {
                     "&client_metadata=$clientMetadataJwksInline"
 
             val resolution = resolver().resolveRequestUri(authRequest)
-            resolution.validateSuccess()
+            resolution.assertIsSuccess()
         }
 
         test(genState())
@@ -233,7 +235,7 @@ class UnvalidatedRequestResolverTest {
 
             val resolution = resolver().resolveRequestUri(authRequest)
 
-            resolution.validateSuccess()
+            resolution.assertIsSuccess()
         }
 
         test(genState())
@@ -271,13 +273,13 @@ class UnvalidatedRequestResolverTest {
         }
 
         test(JOSEObjectType(OpenId4VPSpec.AUTHORIZATION_REQUEST_OBJECT_TYPE)) {
-            it.validateSuccess()
+            it.assertIsSuccess()
         }
 
         listOf(null, JOSEObjectType(""), JOSEObjectType("jwt"))
             .forEach { type ->
                 test(type) {
-                    it.validateInvalid<RequestValidationError.InvalidJarJwt>()
+                    it.assertIsInvalid<RequestValidationError.InvalidJarJwt>()
                 }
             }
     }
@@ -313,13 +315,13 @@ class UnvalidatedRequestResolverTest {
         }
 
         test(JOSEObjectType(OpenId4VPSpec.AUTHORIZATION_REQUEST_OBJECT_TYPE)) {
-            it.validateSuccess()
+            it.assertIsSuccess()
         }
 
         listOf(null, JOSEObjectType(""), JOSEObjectType("jwt"))
             .forEach { type ->
                 test(type) {
-                    it.validateInvalid<RequestValidationError.InvalidJarJwt>()
+                    it.assertIsInvalid<RequestValidationError.InvalidJarJwt>()
                 }
             }
     }
@@ -357,13 +359,13 @@ class UnvalidatedRequestResolverTest {
         }
 
         test(JOSEObjectType(OpenId4VPSpec.AUTHORIZATION_REQUEST_OBJECT_TYPE)) {
-            it.validateSuccess()
+            it.assertIsSuccess()
         }
 
         listOf(null, JOSEObjectType(""), JOSEObjectType("jwt"))
             .forEach { type ->
                 test(type) {
-                    it.validateInvalid<RequestValidationError.InvalidJarJwt>()
+                    it.assertIsInvalid<RequestValidationError.InvalidJarJwt>()
                 }
             }
     }
@@ -418,7 +420,7 @@ class UnvalidatedRequestResolverTest {
                 "&client_metadata=$clientMetadata"
 
         val resolution = resolver().resolveRequestUri(authRequest)
-        resolution.validateInvalid<ResolutionError.ClientVpFormatsNotSupportedFromWallet>()
+        resolution.assertIsInvalid<ResolutionError.ClientVpFormatsNotSupportedFromWallet>()
     }
 
     @Test
@@ -451,7 +453,7 @@ class UnvalidatedRequestResolverTest {
                 "&client_metadata=$clientMetadata"
 
         val resolution = resolver().resolveRequestUri(authRequest)
-        with(resolution.validateSuccess()) {
+        with(resolution.assertIsSuccess()) {
             with(assertNotNull(vpFormatsSupported)) {
                 assertNotNull(sdJwtVc)
                 assertEquals(listOf(JWSAlgorithm.ES512), sdJwtVc.sdJwtAlgorithms)
@@ -472,7 +474,7 @@ class UnvalidatedRequestResolverTest {
                 "&dcql_query=$dcqlQuery"
 
         val resolution = resolver().resolveRequestUri(authRequest)
-        val request = resolution.validateSuccess()
+        val request = resolution.assertIsSuccess()
 
         assertNull(request.vpFormatsSupported)
     }
@@ -503,7 +505,7 @@ class UnvalidatedRequestResolverTest {
                 "&client_metadata=$clientMetadata"
 
         val resolution = resolver().resolveRequestUri(authRequest)
-        val request = resolution.validateSuccess()
+        val request = resolution.assertIsSuccess()
         val formats = request.vpFormatsSupported
         val sdJwtFormat = assertNotNull(formats?.sdJwtVc)
 
@@ -552,7 +554,7 @@ class UnvalidatedRequestResolverTest {
                 "&client_metadata=$clientMetadata"
 
         val resolution = resolver().resolveRequestUri(authRequest)
-        val request = resolution.validateSuccess()
+        val request = resolution.assertIsSuccess()
         val formats = request.vpFormatsSupported
         assertNull(formats?.sdJwtVc)
         val msoMdocFormat = assertNotNull(formats?.msoMdoc)
@@ -652,7 +654,7 @@ class UnvalidatedRequestResolverTest {
 
             val resolution = resolver().resolveRequestUri(authRequest)
 
-            resolution.validateInvalid<RequestValidationError.UnsupportedResponseType>()
+            resolution.assertIsInvalid<RequestValidationError.UnsupportedResponseType>()
         }
 
         test(genState())
@@ -672,7 +674,7 @@ class UnvalidatedRequestResolverTest {
 
             val resolution = resolver().resolveRequestUri(authRequest)
 
-            resolution.validateInvalid<RequestValidationError.MissingNonce>()
+            resolution.assertIsInvalid<RequestValidationError.MissingNonce>()
         }
 
         test(genState())
@@ -692,7 +694,7 @@ class UnvalidatedRequestResolverTest {
 
             val resolution = resolver().resolveRequestUri(authRequest)
 
-            resolution.validateInvalid<RequestValidationError.MissingClientId>()
+            resolution.assertIsInvalid<RequestValidationError.MissingClientId>()
         }
 
         test(genState())
@@ -717,17 +719,302 @@ class UnvalidatedRequestResolverTest {
     private fun load(f: String): InputStream =
         UnvalidatedRequestResolverTest::class.java.classLoader.getResourceAsStream(f) ?: error("File $f not found")
 
-    private fun Resolution.validateSuccess(): ResolvedRequestObject =
+    private fun Resolution.assertIsSuccess(): ResolvedRequestObject =
         when (this) {
             is Resolution.Success -> requestObject
             is Resolution.Invalid -> fail("Invalid resolution found while expected success\n$error")
         }
 
-    private inline fun <reified T : AuthorizationRequestError> Resolution.validateInvalid(): T =
+    private inline fun <reified T : AuthorizationRequestError> Resolution.assertIsInvalid(): T =
         when (this) {
             is Resolution.Invalid -> assertIs(error, "${T::class} error expected")
             else -> fail("Success resolution found while expected Invalid")
         }
+
+    @DisplayName("when authorization request comes through DC API channel")
+    @Nested
+    inner class RequestResolutionOverDCApiTest {
+
+        private val dcqlQuery = readFileAsText("dcql/basic_example.json")
+            .replace("\r\n", "")
+            .replace("\r", "")
+            .replace("\n", "")
+            .replace("  ", "")
+
+        private val resolver = DefaultRequestResolverOverDCApi(walletConfig, httpClient)
+
+        private val clientMetadata =
+            """ {
+                 "jwks": $jwkSetJO,
+                 "vp_formats_supported": {
+                     "dc+sd-jwt": {
+                         "sd-jwt_alg_values": ["RS256", "ES512", "ES256", "ES384"],
+                         "kb-jwt_alg_values": ["RS256", "ES512", "ES384"]
+                     }
+                 }    
+               }
+            """.trimIndent()
+
+        private fun jwtClaimsSetDCApiRequest(
+            clientId: String? = null,
+            clientMetadata: UnvalidatedClientMetaData? = null,
+            responseMode: String? = "dc_api",
+            expectedOrigins: List<String>? = null,
+        ): JWTClaimsSet =
+            with(JWTClaimsSet.Builder()) {
+                audience("https://self-issued.me/v2")
+                issueTime(Date())
+                clientId?.let { claim("client_id", clientId) }
+                claim("response_type", "vp_token")
+                claim("nonce", "nonce")
+                claim("response_mode", responseMode)
+                claim("dcql_query", Jackson.toJsonObject(Json.decodeFromString<JsonObject>(dcqlQuery)))
+                claim("state", "638JwH0b2jrhGlAZQVa50KysVazkI-YpiFcLj2DLMalJpZK6XC22vAsPqXkpwAwXzfYpK-WLc3GhHYK8lbT6rw")
+                clientMetadata?.let { claim("client_metadata", Jackson.toJsonObject(clientMetadata)) }
+                expectedOrigins?.let { claim("expected_origins", expectedOrigins) }
+                build()
+            }
+
+        @Test
+        fun `nonce is mandatory to exist`() = runTest {
+            val requestData = buildJsonObject {
+                put("response_mode", "dc_api")
+                put("dcql_query", jsonSupport.decodeFromString<JsonObject>(dcqlQuery))
+                put("client_metadata", jsonSupport.decodeFromString<JsonObject>(clientMetadata))
+            }
+            val resolution = resolver.resolveRequestObject(
+                OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_UNSIGNED,
+                "test_origin",
+                requestData,
+            )
+            assertIs<Resolution.Invalid>(resolution)
+            assertIs<RequestValidationError.MissingNonce>(resolution.error)
+        }
+
+        @Test
+        fun `response_mode must be dc_api or dc_api jwt`() = runTest {
+            val requestData = buildJsonObject {
+                put("response_mode", "fragment")
+                put("nonce", "n-0S6_WzA2Mj")
+                put("dcql_query", jsonSupport.decodeFromString<JsonObject>(dcqlQuery))
+                put("client_metadata", jsonSupport.decodeFromString<JsonObject>(clientMetadata))
+            }
+            val resolution = resolver.resolveRequestObject(
+                OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_UNSIGNED,
+                "test_origin",
+                requestData,
+            )
+            val invalid = resolution.assertIsInvalid<RequestValidationError.UnsupportedResponseMode>()
+            assertEquals("fragment", invalid.value)
+        }
+
+        @Test
+        fun `response_type is ignored if provided in request`() = runTest {
+            val requestData = buildJsonObject {
+                put("response_type", "id_token")
+                put("response_mode", "dc_api")
+                put("nonce", "n-0S6_WzA2Mj")
+                put("dcql_query", jsonSupport.decodeFromString<JsonObject>(dcqlQuery))
+                put("client_metadata", jsonSupport.decodeFromString<JsonObject>(clientMetadata))
+            }
+            val resolution = resolver.resolveRequestObject(
+                OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_UNSIGNED,
+                "test_origin",
+                requestData,
+            )
+            val request = resolution.assertIsSuccess()
+            assertIs<Client.Origin>(request.client)
+            assertEquals("test_origin", request.client.clientId)
+        }
+
+        @Test
+        fun `and no presentation query passed, resolution fails`() = runTest {
+            val requestData = buildJsonObject {
+                put("response_mode", "dc_api")
+                put("nonce", "n-0S6_WzA2Mj")
+                put("client_metadata", jsonSupport.decodeFromString<JsonObject>(clientMetadata))
+            }
+            val resolution = resolver.resolveRequestObject(
+                OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_UNSIGNED,
+                "test_origin",
+                requestData,
+            )
+            resolution.assertIsInvalid<RequestValidationError.MissingQuerySource>()
+        }
+
+        @Test
+        fun `if response_mode is dc_api jwt, client metadata must be included in request`() = runTest {
+            val requestData = buildJsonObject {
+                put("response_mode", "dc_api.jwt")
+                put("nonce", "n-0S6_WzA2Mj")
+                put("dcql_query", jsonSupport.decodeFromString<JsonObject>(dcqlQuery))
+            }
+            val resolution = resolver.resolveRequestObject(
+                OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_UNSIGNED,
+                "test_origin",
+                requestData,
+            )
+            val invalid = resolution.assertIsInvalid<RequestValidationError.InvalidClientMetaData>()
+            assertEquals("Missing client metadata", invalid.cause)
+        }
+
+        @Test
+        fun `if exchange protocol is not supported, resolution fails`() = runTest {
+            val requestData = buildJsonObject {
+                put("response_mode", "dc_api.jwt")
+                put("nonce", "n-0S6_WzA2Mj")
+                put("dcql_query", jsonSupport.decodeFromString<JsonObject>(dcqlQuery))
+            }
+            var resolution = resolver.resolveRequestObject("org-iso-mdoc", "test_origin", requestData)
+            resolution.assertIsInvalid<ResolutionError.UnsupportedDcApiExchangeProtocol>()
+
+            resolution = resolver.resolveRequestObject(
+                OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_SIGNED, "test_origin", requestData,
+            )
+            resolution.assertIsInvalid<ResolutionError.DcApiExchangeProtocolNotMatchesReceivedRequest>()
+        }
+
+        @Test
+        fun `client_id is ignored if provided in request`() = runTest {
+            val requestData = buildJsonObject {
+                put("client_id", "client_id")
+                put("response_mode", "dc_api")
+                put("nonce", "n-0S6_WzA2Mj")
+                put("dcql_query", jsonSupport.decodeFromString<JsonObject>(dcqlQuery))
+                put("client_metadata", jsonSupport.decodeFromString<JsonObject>(clientMetadata))
+            }
+            val resolution = resolver.resolveRequestObject(
+                OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_UNSIGNED,
+                "test_origin",
+                requestData,
+            )
+            val request = resolution.assertIsSuccess()
+            assertIs<Client.Origin>(request.client)
+            assertEquals("test_origin", request.client.clientId)
+        }
+
+        @Test
+        fun `verifier attestations are parsed correctly`() = runTest {
+            val requestData = buildJsonObject {
+                put("response_mode", "dc_api")
+                put("nonce", "n-0S6_WzA2Mj")
+                put("dcql_query", jsonSupport.decodeFromString<JsonObject>(dcqlQuery))
+                put("client_metadata", jsonSupport.decodeFromString<JsonObject>(clientMetadata))
+                putJsonArray("verifier_info", {
+                    add(
+                        buildJsonObject {
+                            put("format", "jwt")
+                            put("data", "attestation_data")
+                        },
+                    )
+                    add(
+                        buildJsonObject {
+                            put("format", "jwt")
+                            put("data", "attestation_data_1")
+                        },
+                    )
+                })
+            }
+            val resolution = resolver.resolveRequestObject(
+                OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_UNSIGNED,
+                "test_origin",
+                requestData,
+            )
+            val request = resolution.assertIsSuccess()
+
+            assertNotNull(request.verifierInfo)
+
+            val jwtAttestations = request.verifierInfo.attestations.filter {
+                it.format == VerifierInfo.Attestation.Format.Jwt
+            }.size
+            assertEquals(2, jwtAttestations)
+        }
+
+        @Test
+        fun `when request is of JWS compact serialization form, it is parsed properly`() = runTest {
+            val keyStore = KeyStore.getInstance("JKS")
+            keyStore.load(
+                load("certificates/certificates.jks"),
+                "12345".toCharArray(),
+            )
+            val clientId = "x509_san_dns:verifier.example.gr"
+            val jwtClaimsSet = jwtClaimsSetDCApiRequest(
+                clientId = clientId,
+                responseMode = "dc_api",
+                expectedOrigins = listOf("test_origin"),
+            )
+            val typ = JOSEObjectType(OpenId4VPSpec.AUTHORIZATION_REQUEST_OBJECT_TYPE)
+            val signedJwt = createSignedRequestJwt(keyStore, jwtClaimsSet, typ)
+
+            val requestData = buildJsonObject {
+                put("request", signedJwt)
+            }
+            val resolution = resolver.resolveRequestObject(
+                OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_SIGNED,
+                "test_origin",
+                requestData,
+            )
+            val request = resolution.assertIsSuccess()
+            assertIs<Client.X509SanDns>(request.client)
+        }
+
+        @Test
+        fun `if request is signed and expected_origins is missing, fail resolution with MissingExpectedOrigins`() = runTest {
+            val keyStore = KeyStore.getInstance("JKS")
+            keyStore.load(
+                load("certificates/certificates.jks"),
+                "12345".toCharArray(),
+            )
+            val clientId = "x509_san_dns:verifier.example.gr"
+            // Request with no expected_origins
+            val jwtClaimsSet = jwtClaimsSetDCApiRequest(
+                clientId = clientId,
+                responseMode = "dc_api",
+            )
+            val typ = JOSEObjectType(OpenId4VPSpec.AUTHORIZATION_REQUEST_OBJECT_TYPE)
+            val signedJwt = createSignedRequestJwt(keyStore, jwtClaimsSet, typ)
+
+            val requestData = buildJsonObject {
+                put("request", signedJwt)
+            }
+
+            val resolution = resolver.resolveRequestObject(
+                OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_SIGNED,
+                "test_origin",
+                requestData,
+            )
+            resolution.assertIsInvalid<MissingExpectedOrigins>()
+        }
+
+        @Test
+        fun `if request is signed, caller info's origin must be one of the expected_origins`() = runTest {
+            val keyStore = KeyStore.getInstance("JKS")
+            keyStore.load(
+                load("certificates/certificates.jks"),
+                "12345".toCharArray(),
+            )
+            val clientId = "x509_san_dns:verifier.example.gr"
+            // Request with no expected_origins
+            val jwtClaimsSet = jwtClaimsSetDCApiRequest(
+                clientId = clientId,
+                responseMode = "dc_api",
+                expectedOrigins = listOf("origin_1", "origin_2"),
+            )
+            val typ = JOSEObjectType(OpenId4VPSpec.AUTHORIZATION_REQUEST_OBJECT_TYPE)
+            val signedJwt = createSignedRequestJwt(keyStore, jwtClaimsSet, typ)
+
+            val requestData = buildJsonObject {
+                put("request", signedJwt)
+            }
+
+            val resolution = resolver.resolveRequestObject(
+                OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_SIGNED,
+                "test_origin",
+                requestData,
+            )
+            resolution.assertIsInvalid<UnexpectedOrigin>()
+        }
+    }
 
     @DisplayName("when using transaction_data")
     @Nested
@@ -781,7 +1068,7 @@ class UnvalidatedRequestResolverTest {
         fun `if transaction_data contains non base64url encoded values, resolution fails`() = runTest {
             val transactionData = JsonArray(listOf(JsonPrimitive("invalid")))
             testAndThen(transactionData, queryWithSingleCredential) {
-                val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
+                val error = it.assertIsInvalid<ResolutionError.InvalidTransactionData>()
                 val cause = assertIs<IllegalArgumentException>(error.cause)
                 assertEquals("The pad bits must be zeros", cause.message)
             }
@@ -791,7 +1078,7 @@ class UnvalidatedRequestResolverTest {
         fun `if transaction_data contains non JsonObject values, resolution fails`() = runTest {
             val transactionData = JsonArray(listOf(JsonPrimitive(base64UrlNoPadding.encode("foo".encodeToByteArray()))))
             testAndThen(transactionData, queryWithSingleCredential) {
-                val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
+                val error = it.assertIsInvalid<ResolutionError.InvalidTransactionData>()
                 val cause = assertIs<SerializationException>(error.cause)
                 assertEquals(
                     "Unexpected JSON token at offset 0: Expected start of the object '{', but had 'f' instead at path: $\nJSON input: foo",
@@ -804,7 +1091,7 @@ class UnvalidatedRequestResolverTest {
         fun `if transaction_data contains no type, resolution fails`() = runTest {
             val transactionData = JsonObject(emptyMap())
             testAndThen(transactionData, queryWithSingleCredential) {
-                val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
+                val error = it.assertIsInvalid<ResolutionError.InvalidTransactionData>()
                 val cause = assertIs<IllegalArgumentException>(error.cause)
                 assertEquals(
                     "Missing required property 'type'",
@@ -819,7 +1106,7 @@ class UnvalidatedRequestResolverTest {
                 put(OpenId4VPSpec.TRANSACTION_DATA_TYPE, 10)
             }
             testAndThen(transactionData, queryWithSingleCredential) {
-                val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
+                val error = it.assertIsInvalid<ResolutionError.InvalidTransactionData>()
                 val cause = assertIs<IllegalArgumentException>(error.cause)
                 assertEquals(
                     "Property 'type' is not a string'",
@@ -835,7 +1122,7 @@ class UnvalidatedRequestResolverTest {
                 listOf(QueryId("my_credential")),
             )
             testAndThen(transactionData.json, queryWithSingleCredential) {
-                val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
+                val error = it.assertIsInvalid<ResolutionError.InvalidTransactionData>()
                 val cause = assertIs<IllegalArgumentException>(error.cause)
                 assertEquals(
                     "Unsupported Transaction Data 'type': 'unsupported'",
@@ -850,7 +1137,7 @@ class UnvalidatedRequestResolverTest {
                 put(OpenId4VPSpec.TRANSACTION_DATA_TYPE, "basic-transaction-data")
             }
             testAndThen(transactionData, queryWithSingleCredential) {
-                val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
+                val error = it.assertIsInvalid<ResolutionError.InvalidTransactionData>()
                 val cause = assertIs<IllegalArgumentException>(error.cause)
                 assertEquals(
                     "Missing required property 'credential_ids'",
@@ -868,7 +1155,7 @@ class UnvalidatedRequestResolverTest {
                 }
             }
             testAndThen(transactionData, queryWithSingleCredential) {
-                val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
+                val error = it.assertIsInvalid<ResolutionError.InvalidTransactionData>()
                 val cause = assertIs<IllegalArgumentException>(error.cause)
                 assertEquals(
                     "Property 'credential_ids' is not an array or contains non string values",
@@ -885,7 +1172,7 @@ class UnvalidatedRequestResolverTest {
                     listOf(QueryId("invalid-id")),
                 )
                 testAndThen(transactionData.json, queryWithSingleCredential) {
-                    val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
+                    val error = it.assertIsInvalid<ResolutionError.InvalidTransactionData>()
                     val cause = assertIs<IllegalArgumentException>(error.cause)
                     assertEquals(
                         "Invalid Transaction Data 'credential_ids': '[invalid-id]'",
@@ -901,7 +1188,7 @@ class UnvalidatedRequestResolverTest {
                 listOf(QueryId("invalid-id")),
             )
             testAndThen(transactionData.json, queryWithSingleCredential) {
-                val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
+                val error = it.assertIsInvalid<ResolutionError.InvalidTransactionData>()
                 val cause = assertIs<IllegalArgumentException>(error.cause)
                 assertEquals(
                     "Invalid Transaction Data 'credential_ids': '[invalid-id]'",
@@ -917,7 +1204,7 @@ class UnvalidatedRequestResolverTest {
                 listOf(QueryId("my_credential_1"), QueryId("my_credential_2")),
             )
             testAndThen(transactionData.json, queryWithMultipleCredentials) {
-                val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
+                val error = it.assertIsInvalid<ResolutionError.InvalidTransactionData>()
                 val cause = assertIs<IllegalArgumentException>(error.cause)
                 assertEquals(
                     "Transaction Data must refer to Credentials that use the same Format",
@@ -936,7 +1223,7 @@ class UnvalidatedRequestResolverTest {
                 put(OpenId4VPSpec.TRANSACTION_DATA_HASH_ALGORITHMS, "invalid")
             }
             testAndThen(transactionData, queryWithSingleCredential) {
-                val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
+                val error = it.assertIsInvalid<ResolutionError.InvalidTransactionData>()
                 val cause = assertIs<IllegalArgumentException>(error.cause)
                 assertEquals(
                     "Property 'transaction_data_hashes_alg' is not an array or contains non string values",
@@ -957,7 +1244,7 @@ class UnvalidatedRequestResolverTest {
                 }
             }
             testAndThen(transactionData, queryWithSingleCredential) {
-                val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
+                val error = it.assertIsInvalid<ResolutionError.InvalidTransactionData>()
                 val cause = assertIs<IllegalArgumentException>(error.cause)
                 assertEquals(
                     "Property 'transaction_data_hashes_alg' is not an array or contains non string values",
@@ -974,7 +1261,7 @@ class UnvalidatedRequestResolverTest {
                 listOf(HashAlgorithm("sha-512")),
             )
             testAndThen(transactionData.json, queryWithSingleCredential) {
-                val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
+                val error = it.assertIsInvalid<ResolutionError.InvalidTransactionData>()
                 val cause = assertIs<IllegalArgumentException>(error.cause)
                 assertEquals(
                     "Unsupported Transaction Data 'transaction_data_hashes_alg': '[sha-512]'",
@@ -991,7 +1278,7 @@ class UnvalidatedRequestResolverTest {
                 listOf(HashAlgorithm.SHA_256),
             )
             testAndThen(transactionData.json, queryWithSingleCredential) {
-                val request = it.validateSuccess()
+                val request = it.assertIsSuccess()
                 val resolvedTransactionData = run {
                     val resolvedTransactionData = assertNotNull(request.transactionData)
                     assertEquals(1, resolvedTransactionData.size)
@@ -1014,7 +1301,7 @@ class UnvalidatedRequestResolverTest {
                 listOf(HashAlgorithm.SHA_256),
             )
             testAndThen(transactionData.json, queryWithSingleCredential) {
-                val request = it.validateSuccess()
+                val request = it.assertIsSuccess()
                 val resolvedTransactionData = run {
                     val resolvedTransactionData = assertNotNull(request.transactionData)
                     assertEquals(1, resolvedTransactionData.size)
@@ -1037,7 +1324,7 @@ class UnvalidatedRequestResolverTest {
                     listOf(QueryId("my_credential")),
                 )
                 testAndThen(transactionData.json, queryWithSingleCredential) {
-                    val request = it.validateSuccess()
+                    val request = it.assertIsSuccess()
                     val resolvedTransactionData = run {
                         val resolvedTransactionData = assertNotNull(request.transactionData)
                         assertEquals(1, resolvedTransactionData.size)
@@ -1060,7 +1347,7 @@ class UnvalidatedRequestResolverTest {
                 listOf(HashAlgorithm("sha-384")),
             )
             testAndThen(transactionData.json, queryWithSingleCredential) {
-                val request = it.validateSuccess()
+                val request = it.assertIsSuccess()
                 val resolvedTransactionData = run {
                     val resolvedTransactionData = assertNotNull(request.transactionData)
                     assertEquals(1, resolvedTransactionData.size)
@@ -1082,7 +1369,7 @@ class UnvalidatedRequestResolverTest {
                 listOf(QueryId("my_credential_2")),
             )
             testAndThen(transactionData.json, queryWithMultipleCredentials) {
-                val error = it.validateInvalid<ResolutionError.InvalidTransactionData>()
+                val error = it.assertIsInvalid<ResolutionError.InvalidTransactionData>()
                 val cause = assertIs<IllegalArgumentException>(error.cause)
                 assertEquals(
                     "Unsupported Transaction Data Format 'mso_mdoc'",

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
@@ -38,6 +38,8 @@ import eu.europa.ec.eudi.openid4vp.internal.jsonSupport
 import eu.europa.ec.eudi.openid4vp.internal.request.DefaultRequestResolverOverDCApi
 import eu.europa.ec.eudi.openid4vp.internal.request.DefaultRequestResolverOverHttp
 import eu.europa.ec.eudi.openid4vp.internal.request.UnvalidatedClientMetaData
+import eu.europa.ec.eudi.openid4vp.internal.request.UnvalidatedRequestObject
+import eu.europa.ec.eudi.openid4vp.internal.request.randomKey
 import io.ktor.client.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.serialization.kotlinx.json.*
@@ -46,6 +48,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.MissingFieldException
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.*
 import org.apache.http.NameValuePair
 import org.apache.http.client.utils.URIBuilder
@@ -137,6 +140,8 @@ class UnvalidatedRequestResolverTest {
         """.trimIndent(),
     ).jsonObject
 
+    val didAlgAndKey = randomKey()
+
     private val walletConfig = OpenId4VPConfig(
         supportedClientIdPrefixes = listOf(
             SupportedClientIdPrefix.Preregistered(
@@ -153,9 +158,11 @@ class UnvalidatedRequestResolverTest {
             SupportedClientIdPrefix.RedirectUri,
             SupportedClientIdPrefix.X509SanDns(::validateChain),
             SupportedClientIdPrefix.X509Hash(::validateChain),
+            SupportedClientIdPrefix.DecentralizedIdentifier({ _ -> didAlgAndKey.second.toECPublicKey() }),
         ),
         signedRequestConfiguration = SignedRequestConfiguration(
             supportedAlgorithms = listOf(JWSAlgorithm.RS256),
+            multiSignedRequestsPolicy = MultiSignedRequestsPolicy.Expect(ClientIdPrefix.DecentralizedIdentifier),
         ),
         vpConfiguration = VPConfiguration(
             vpFormatsSupported = VpFormatsSupported(
@@ -875,7 +882,7 @@ class UnvalidatedRequestResolverTest {
         }
 
         @Test
-        fun `client_id is ignored if provided in request`() = runTest {
+        fun `client_id is ignored if provided in unsigned request`() = runTest {
             val requestData = buildJsonObject {
                 put("client_id", "client_id")
                 put("response_mode", "dc_api")
@@ -1031,6 +1038,57 @@ class UnvalidatedRequestResolverTest {
                 requestData,
             )
             resolution.assertIsInvalid<UnexpectedOrigin>()
+        }
+
+        @Test
+        fun `if request is multi-signed, client in resolved request object must match wallet's configuration`() = runTest {
+            val request = UnvalidatedRequestObject(
+                responseMode = "dc_api",
+                nonce = "nonce",
+                dcqlQuery = jsonSupport.decodeFromString<JsonObject>(dcqlQuery),
+                expectedOrigins = listOf("test_origin", "test_origin_alt"),
+            ).multiSigned(
+                listOf(
+                    didSigner(didAlgAndKey),
+                ),
+            )
+            val requestData = buildJsonObject {
+                put("request", Json.encodeToJsonElement(request.jwsJson))
+            }
+
+            val resolution = resolver.resolveRequestObject(
+                OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_MULTISIGNED,
+                "test_origin",
+                requestData.jsonObject,
+            )
+
+            val resolvedRequestObject = resolution.assertIsSuccess()
+            assertIs<Client.DecentralizedIdentifier>(resolvedRequestObject.client)
+        }
+
+        @Test
+        fun `if request is multi-signed, if no matching client authentication present, resolution fails`() = runTest {
+            val request = UnvalidatedRequestObject(
+                responseMode = "dc_api",
+                nonce = "nonce",
+                dcqlQuery = jsonSupport.decodeFromString<JsonObject>(dcqlQuery),
+                expectedOrigins = listOf("test_origin", "test_origin_alt"),
+            ).multiSigned(
+                listOf(
+                    verifierAttestationSigner(didAlgAndKey, Clock.systemDefaultZone()),
+                ),
+            )
+            val requestData = buildJsonObject {
+                put("request", Json.encodeToJsonElement(request.jwsJson))
+            }
+
+            val resolution = resolver.resolveRequestObject(
+                OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_MULTISIGNED,
+                "test_origin",
+                requestData.jsonObject,
+            )
+
+            resolution.assertIsInvalid<RequestValidationError.NoMatchingClientPrefixInMultiSignedRequest>()
         }
     }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/UnvalidatedRequestResolverTest.kt
@@ -894,6 +894,24 @@ class UnvalidatedRequestResolverTest {
         }
 
         @Test
+        fun `client_id is not mandatory to exist in unsigned request over DC API`() = runTest {
+            val requestData = buildJsonObject {
+                put("response_mode", "dc_api")
+                put("nonce", "n-0S6_WzA2Mj")
+                put("dcql_query", jsonSupport.decodeFromString<JsonObject>(dcqlQuery))
+                put("client_metadata", jsonSupport.decodeFromString<JsonObject>(clientMetadata))
+            }
+            val resolution = resolver.resolveRequestObject(
+                OpenId4VPSpec.DC_API_EXCHANGE_PROTOCOL_UNSIGNED,
+                "test_origin",
+                requestData,
+            )
+            val request = resolution.assertIsSuccess()
+            assertIs<Client.Origin>(request.client)
+            assertEquals("test_origin", request.client.clientId)
+        }
+
+        @Test
         fun `verifier attestations are parsed correctly`() = runTest {
             val requestData = buildJsonObject {
                 put("response_mode", "dc_api")

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticatorTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticatorTest.kt
@@ -26,8 +26,7 @@ import com.nimbusds.jose.util.Base64URL
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.openid4vp.*
-import eu.europa.ec.eudi.openid4vp.internal.AbsoluteDIDUrl
-import eu.europa.ec.eudi.openid4vp.internal.DID
+import eu.europa.ec.eudi.openid4vp.internal.*
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.DisplayName
@@ -35,12 +34,10 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.assertThrows
 import java.net.URI
 import java.time.Clock
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
+import kotlin.test.*
 
-class ClientAuthenticatorTest {
+@DisplayName("In case of request is coming through HTTP")
+class ClientAuthenticatorOverHTTPTest {
 
     @DisplayName("when handling a request")
     @Nested
@@ -67,7 +64,7 @@ class ClientAuthenticatorTest {
         fun `if client_id is missing, authentication fails`() = runTest {
             val request = UnvalidatedRequestObject(clientId = null).unsigned()
             assertFailsWithError<RequestValidationError.MissingClientId> {
-                clientAuthenticator.authenticateClient(request)
+                clientAuthenticator.authenticateClientOverHttp(request)
             }
         }
     }
@@ -99,7 +96,7 @@ class ClientAuthenticatorTest {
                     clientId = "redirect_uri:$clientId",
                 ).unsigned()
 
-                val client = clientAuthenticator.authenticateClient(request)
+                val client = clientAuthenticator.authenticateClientOverHttp(request)
                 assertEquals(AuthenticatedClient.RedirectUri(clientId), client)
             }
 
@@ -111,7 +108,7 @@ class ClientAuthenticatorTest {
             ).signed(alg, key)
 
             val error = assertFailsWithError<RequestValidationError.InvalidClientIdPrefix> {
-                clientAuthenticator.authenticateClient(request)
+                clientAuthenticator.authenticateClientOverHttp(request)
             }
             assertEquals("RedirectUri cannot be used in signed request", error.value)
         }
@@ -123,7 +120,7 @@ class ClientAuthenticatorTest {
                 clientId = "redirect_uri:$httpClientId",
             ).unsigned()
 
-            assertThrows<AuthorizationRequestException> { clientAuthenticator.authenticateClient(request) }
+            assertThrows<AuthorizationRequestException> { clientAuthenticator.authenticateClientOverHttp(request) }
         }
     }
 
@@ -166,7 +163,7 @@ class ClientAuthenticatorTest {
                     clientId = "testPreRegistered",
                 ).signed(alg, key)
 
-                val client = clientAuthenticator.authenticateClient(request)
+                val client = clientAuthenticator.authenticateClientOverHttp(request)
                 assertEquals(AuthenticatedClient.Preregistered(preRegisteredClient), client)
             }
 
@@ -179,7 +176,7 @@ class ClientAuthenticatorTest {
                 ).signed(alg, key)
 
                 val authenticateClient =
-                    assertIs<AuthenticatedClient.Preregistered>(clientAuthenticator.authenticateClient(request))
+                    assertIs<AuthenticatedClient.Preregistered>(clientAuthenticator.authenticateClientOverHttp(request))
                 assertEquals(preRegisteredClientFooBar, authenticateClient.preregisteredClient)
             }
     }
@@ -218,7 +215,7 @@ class ClientAuthenticatorTest {
             val request = requestObject.unsigned()
 
             val error = assertFailsWithError<RequestValidationError.InvalidClientIdPrefix> {
-                clientAuthenticator.authenticateClient(request)
+                clientAuthenticator.authenticateClientOverHttp(request)
             }
             assertTrue {
                 error.value.endsWith("cannot be used in unsigned request")
@@ -233,7 +230,7 @@ class ClientAuthenticatorTest {
             val request = requestObject.signed(alg, key)
 
             val error = assertFailsWithError<RequestValidationError.InvalidJarJwt> {
-                clientAuthenticator.authenticateClient(request)
+                clientAuthenticator.authenticateClientOverHttp(request)
             }
             assertTrue {
                 error.cause.startsWith("Missing kid")
@@ -247,7 +244,7 @@ class ClientAuthenticatorTest {
             val request = requestObject.signed(alg, key) { keyID("foo") }
 
             val error = assertFailsWithError<RequestValidationError.InvalidJarJwt> {
-                clientAuthenticator.authenticateClient(request)
+                clientAuthenticator.authenticateClientOverHttp(request)
             }
             assertTrue {
                 error.cause.endsWith("kid should be DID URL")
@@ -262,7 +259,7 @@ class ClientAuthenticatorTest {
             val request = requestObject.signed(alg, key) { keyID("did:foo:bar#1") }
 
             val error = assertFailsWithError<RequestValidationError.InvalidJarJwt> {
-                clientAuthenticator.authenticateClient(request)
+                clientAuthenticator.authenticateClientOverHttp(request)
             }
             assertTrue {
                 error.cause.contains("kid should be DID URL sub-resource")
@@ -285,7 +282,7 @@ class ClientAuthenticatorTest {
 
             val request = requestObject.signed(alg, key) { keyID(keyUrl.toString()) }
             assertFailsWithError<RequestValidationError.DIDResolutionFailed> {
-                clientAuthenticator.authenticateClient(request)
+                clientAuthenticator.authenticateClientOverHttp(request)
             }
         }
 
@@ -293,7 +290,7 @@ class ClientAuthenticatorTest {
         fun `if resolution succeeds, authentication succeeds`() = runTest {
             val (alg, key) = algAndKey
             val request = requestObject.signed(alg, key) { keyID(keyUrl.toString()) }
-            val client = clientAuthenticator.authenticateClient(request)
+            val client = clientAuthenticator.authenticateClientOverHttp(request)
             assertEquals(AuthenticatedClient.DecentralizedIdentifier(originalClientId, key.toPublicKey()), client)
         }
     }
@@ -330,7 +327,7 @@ class ClientAuthenticatorTest {
             val request = requestObject.unsigned()
 
             val error = assertFailsWithError<RequestValidationError.InvalidClientIdPrefix> {
-                clientAuthenticator.authenticateClient(request)
+                clientAuthenticator.authenticateClientOverHttp(request)
             }
             assertTrue {
                 error.value.endsWith("cannot be used in unsigned request")
@@ -342,7 +339,7 @@ class ClientAuthenticatorTest {
             val (alg, key) = algAndKey
             val request = requestObject.signed(alg, key)
             val error = assertFailsWithError<RequestValidationError.InvalidJarJwt> {
-                clientAuthenticator.authenticateClient(request)
+                clientAuthenticator.authenticateClientOverHttp(request)
             }
             assertTrue {
                 error.cause.contains("Missing jwt JOSE Header")
@@ -360,7 +357,7 @@ class ClientAuthenticatorTest {
             )
             val request = requestObject.signedWithAttestation(alg, key, verifierAttestation)
 
-            val client = clientAuthenticator.authenticateClient(request)
+            val client = clientAuthenticator.authenticateClientOverHttp(request)
             assertIs<AuthenticatedClient.VerifierAttestation>(client)
             assertEquals(clientId, client.clientId)
             assertEquals(AttestationIssuer.ID, client.claims.iss)
@@ -397,9 +394,140 @@ class ClientAuthenticatorTest {
 
             val request = requestObject.signedWithAttestation(alg, key, verifierAttestation)
             val error = assertFailsWithError<RequestValidationError.InvalidJarJwt> {
-                clientAuthenticator.authenticateClient(request)
+                clientAuthenticator.authenticateClientOverHttp(request)
             }
             assertTrue { "Not trusted" in error.cause }
+        }
+    }
+}
+
+@DisplayName("In case of request is coming through DC API")
+class RequestAuthenticatorOverDCApiTest {
+
+    private val didAlgAndKey = randomKey()
+
+    private val x509SanDnsSupportedPrefix = SupportedClientIdPrefix.X509SanDns({ _ -> true })
+    private val didSupportedScheme = SupportedClientIdPrefix.DecentralizedIdentifier({ _ -> didAlgAndKey.second.toPublicKey() })
+
+    private val cfg = OpenId4VPConfig(
+        vpConfiguration = VPConfiguration(
+            vpFormatsSupported = VpFormatsSupported(
+                VpFormatsSupported.SdJwtVc.HAIP,
+                VpFormatsSupported.MsoMdoc(
+                    issuerAuthAlgorithms = listOf(CoseAlgorithm(-7)),
+                    deviceAuthAlgorithms = listOf(CoseAlgorithm(-7)),
+                ),
+            ),
+        ),
+        supportedClientIdPrefixes = listOf(x509SanDnsSupportedPrefix, didSupportedScheme),
+        signedRequestConfiguration = SignedRequestConfiguration(
+            supportedAlgorithms = JWSAlgorithm.Family.EC.toList() - JWSAlgorithm.ES256K,
+            supportedRequestUriMethods = SupportedRequestUriMethods.Default,
+            multiSignedRequestsPolicy = MultiSignedRequestsPolicy.Expect(ClientIdPrefix.DecentralizedIdentifier),
+        ),
+    )
+
+    @DisplayName("when handling a request")
+    @Nested
+    inner class AuthenticatorCommonTest {
+
+        private val clientAuthenticator = ClientAuthenticator(cfg)
+        private val requestAuthenticator = RequestAuthenticator(cfg, createHttpClient())
+
+        @Test
+        fun `if request is unsinged the resolved client must be Origin`() = runTest {
+            val request = UnvalidatedRequestObject().unsigned()
+
+            val (authenticateClient, _) = clientAuthenticator.authenticateClientOverDCApi("test_origin", request)
+            assertIs<AuthenticatedClient.Origin>(authenticateClient)
+            assertTrue("test_origin" == authenticateClient.clientId)
+        }
+    }
+
+    @DisplayName("when handling a multi-signed request")
+    @Nested
+    inner class ClientAuthenticatorMultiSignedRequestsTest {
+
+        private val clientAuthenticator = ClientAuthenticator(cfg)
+
+        @Test
+        fun `if expected scheme is found request client is properly authenticated`() = runTest {
+            val request = UnvalidatedRequestObject(
+                expectedOrigins = listOf("test_origin", "test_origin_alt"),
+            ).multiSigned(
+                listOf(didSigner(), verifierAttestationSigner()),
+            )
+            val (authenticateClient, _) = clientAuthenticator.authenticateClientOverDCApi("test_origin", request)
+            assertIs<AuthenticatedClient.DecentralizedIdentifier>(authenticateClient)
+        }
+
+        @Test
+        fun `if request expected scheme is not found in request fail`() = runTest {
+            val request = UnvalidatedRequestObject(
+                expectedOrigins = listOf("test_origin", "test_origin_alt"),
+            ).multiSigned(
+                listOf(verifierAttestationSigner()),
+            )
+            assertFailsWithError<RequestValidationError.NoMatchingClientPrefixInMultiSignedRequest> {
+                clientAuthenticator.authenticateClientOverDCApi("test_origin", request)
+            }
+        }
+
+        private fun didSigner(): SchemeSigner {
+            val (alg2, key2) = didAlgAndKey
+            val originalClientId = DID.parse("did:example:123").getOrThrow()
+            val clientId = "decentralized_identifier:$originalClientId"
+            return SchemeSigner(alg2, key2) {
+                customParam("client_id", clientId)
+                keyID("did:example:123#key-1")
+            }
+        }
+
+        private fun verifierAttestationSigner(): SchemeSigner {
+            val (alg, key) = randomKey()
+            val verifierAttestation = AttestationIssuer.attestation(
+                clock = cfg.clock,
+                clientId = "verifier_attestation:http://example.com",
+                clientPubKey = key.toPublicJWK(),
+            )
+            return SchemeSigner(alg, key) {
+                customParam("client_id", "verifier_attestation:http://www.example.com")
+                customParam("jwt", verifierAttestation.serialize())
+            }
+        }
+
+        @Test
+        fun `can create a multi-signed request`() = runTest {
+            val originalClientId = DID.parse("did:example:123").getOrThrow()
+
+            // Create two signers with different keys
+            val (alg1, key1) = randomKey()
+            val (alg2, key2) = randomKey()
+
+            val signer1 = SchemeSigner(alg1, key1) { keyID(originalClientId.toString()) }
+            val signer2 = SchemeSigner(alg2, key2) { keyID(originalClientId.toString()) }
+
+            // Create a request object with client ID and expected origins
+            val clientId = "decentralized_identifier:$originalClientId"
+            val request = UnvalidatedRequestObject(
+                clientId = clientId,
+                expectedOrigins = listOf("test_origin", "test_origin_alt"),
+            ).multiSigned(listOf(signer1, signer2))
+
+            // Verify that the request is a ReceivedRequest.Signed with a JwsJson.General
+            assertIs<ReceivedRequest.Signed>(request)
+            assertIs<JwsJson.General>(request.jwsJson)
+
+            // Verify that the JwsJson.General has two signatures
+            val jwsJson = request.jwsJson
+            assertEquals(2, jwsJson.signatures.size)
+
+            // Verify that the signatures have the correct protected headers
+            val signature1 = jwsJson.signatures[0]
+            val signature2 = jwsJson.signatures[1]
+
+            assertNotNull(signature1.protected)
+            assertNotNull(signature2.protected)
         }
     }
 }
@@ -443,6 +571,56 @@ private fun UnvalidatedRequestObject.signed(
     }
     return ReceivedRequest.Signed(jwt)
 }
+
+private fun UnvalidatedRequestObject.multiSigned(
+    signers: List<SchemeSigner>,
+): ReceivedRequest.Signed {
+    require(signers.isNotEmpty()) { "At least one signer is required" }
+
+    // Convert the request object to JWT claims
+    val claimsSet = toJWTClaimSet()
+
+    // Create the payload as Base64UrlNoPadding
+    val payloadJson = claimsSet.toString()
+    val payloadBase64 = base64UrlNoPadding.encode(payloadJson.encodeToByteArray())
+    val payload = Base64UrlNoPadding.invoke(payloadBase64).getOrThrow()
+
+    // Create signatures for each signer
+    val signatures = signers.map { signer ->
+        // Create a SignedJWT for this signer
+        val header = with(JWSHeader.Builder(signer.alg)) {
+            type(JOSEObjectType(OpenId4VPSpec.AUTHORIZATION_REQUEST_OBJECT_TYPE))
+            signer.headerCustomization(this)
+            build()
+        }
+
+        // Sign the JWT
+        val jwt = SignedJWT(header, claimsSet).apply {
+            val jwsSigner = DefaultJWSSignerFactory().createJWSSigner(signer.key, signer.alg)
+            sign(jwsSigner)
+        }
+
+        // Extract the parts from the signed JWT
+        val parts = jwt.serialize().split(".")
+        val protectedHeader = Base64UrlNoPadding(parts[0]).getOrThrow()
+        val signature = Base64UrlNoPadding(parts[2]).getOrThrow()
+
+        // Create a Signature object
+        Signature(protected = protectedHeader, signature = signature)
+    }
+
+    // Create a JwsJson.General object with the payload and signatures
+    val jwsJson = JwsJson.General(payload = payload, signatures = signatures)
+
+    // Return a ReceivedRequest.Signed with the JwsJson.General object
+    return ReceivedRequest.Signed(jwsJson)
+}
+
+private class SchemeSigner(
+    val alg: JWSAlgorithm,
+    val key: JWK,
+    val headerCustomization: (JWSHeader.Builder).() -> Unit,
+)
 
 private fun UnvalidatedRequestObject.toJWTClaimSet(): JWTClaimsSet {
     val json = Json.encodeToString(this)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticatorTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticatorTest.kt
@@ -522,7 +522,7 @@ class RequestAuthenticatorOverDCApiTest {
             ).multiSigned(listOf(signer1, signer2))
 
             // Verify that the request is a ReceivedRequest.Signed with a JwsJson.General
-            assertIs<ReceivedRequest.Signed>(request)
+            assertIs<ReceivedRequest.MultiSigned>(request)
             assertIs<JwsJson.General>(request.jwsJson)
 
             // Verify that the JwsJson.General has two signatures
@@ -581,7 +581,7 @@ private fun UnvalidatedRequestObject.signed(
 
 private fun UnvalidatedRequestObject.multiSigned(
     signers: List<SchemeSigner>,
-): ReceivedRequest.Signed {
+): ReceivedRequest.MultiSigned {
     require(signers.isNotEmpty()) { "At least one signer is required" }
 
     // Convert the request object to JWT claims
@@ -620,7 +620,7 @@ private fun UnvalidatedRequestObject.multiSigned(
     val jwsJson = JwsJson.General(payload = payload, signatures = signatures)
 
     // Return a ReceivedRequest.Signed with the JwsJson.General object
-    return ReceivedRequest.Signed(jwsJson)
+    return ReceivedRequest.MultiSigned(jwsJson)
 }
 
 private class SchemeSigner(

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticatorTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticatorTest.kt
@@ -67,6 +67,14 @@ class ClientAuthenticatorOverHTTPTest {
                 clientAuthenticator.authenticateClientOverHttp(request)
             }
         }
+
+        @Test
+        fun `if 'origin' is used as a client id prefix, authentication fails`() = runTest {
+            val request = UnvalidatedRequestObject(clientId = "origin:test_client_id").unsigned()
+            assertFailsWithError<RequestValidationError.InvalidClientIdPrefix> {
+                clientAuthenticator.authenticateClientOverHttp(request)
+            }
+        }
     }
 
     @DisplayName("when handling a request with `redirect_uri` prefix")
@@ -432,7 +440,6 @@ class RequestAuthenticatorOverDCApiTest {
     inner class AuthenticatorCommonTest {
 
         private val clientAuthenticator = ClientAuthenticator(cfg)
-        private val requestAuthenticator = RequestAuthenticator(cfg, createHttpClient())
 
         @Test
         fun `if request is unsinged the resolved client must be Origin`() = runTest {

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticatorTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticatorTest.kt
@@ -23,7 +23,6 @@ import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import com.nimbusds.jose.util.Base64URL
-import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.openid4vp.*
 import eu.europa.ec.eudi.openid4vp.internal.*
@@ -459,10 +458,11 @@ class RequestAuthenticatorOverDCApiTest {
 
         @Test
         fun `if expected scheme is found request client is properly authenticated`() = runTest {
+            val didAlgAndKey = randomKey()
             val request = UnvalidatedRequestObject(
                 expectedOrigins = listOf("test_origin", "test_origin_alt"),
             ).multiSigned(
-                listOf(didSigner(), verifierAttestationSigner()),
+                listOf(didSigner(didAlgAndKey), verifierAttestationSigner(didAlgAndKey, cfg.clock)),
             )
             val (authenticateClient, _) = clientAuthenticator.authenticateClientOverDCApi("test_origin", request)
             assertIs<AuthenticatedClient.DecentralizedIdentifier>(authenticateClient)
@@ -470,36 +470,14 @@ class RequestAuthenticatorOverDCApiTest {
 
         @Test
         fun `if request expected scheme is not found in request fail`() = runTest {
+            val didAlgAndKey = randomKey()
             val request = UnvalidatedRequestObject(
                 expectedOrigins = listOf("test_origin", "test_origin_alt"),
             ).multiSigned(
-                listOf(verifierAttestationSigner()),
+                listOf(verifierAttestationSigner(didAlgAndKey, cfg.clock)),
             )
             assertFailsWithError<RequestValidationError.NoMatchingClientPrefixInMultiSignedRequest> {
                 clientAuthenticator.authenticateClientOverDCApi("test_origin", request)
-            }
-        }
-
-        private fun didSigner(): SchemeSigner {
-            val (alg2, key2) = didAlgAndKey
-            val originalClientId = DID.parse("did:example:123").getOrThrow()
-            val clientId = "decentralized_identifier:$originalClientId"
-            return SchemeSigner(alg2, key2) {
-                customParam("client_id", clientId)
-                keyID("did:example:123#key-1")
-            }
-        }
-
-        private fun verifierAttestationSigner(): SchemeSigner {
-            val (alg, key) = randomKey()
-            val verifierAttestation = AttestationIssuer.attestation(
-                clock = cfg.clock,
-                clientId = "verifier_attestation:http://example.com",
-                clientPubKey = key.toPublicJWK(),
-            )
-            return SchemeSigner(alg, key) {
-                customParam("client_id", "verifier_attestation:http://www.example.com")
-                customParam("jwt", verifierAttestation.serialize())
             }
         }
 
@@ -577,59 +555,4 @@ private fun UnvalidatedRequestObject.signed(
         sign(signer)
     }
     return ReceivedRequest.Signed(jwt)
-}
-
-private fun UnvalidatedRequestObject.multiSigned(
-    signers: List<SchemeSigner>,
-): ReceivedRequest.MultiSigned {
-    require(signers.isNotEmpty()) { "At least one signer is required" }
-
-    // Convert the request object to JWT claims
-    val claimsSet = toJWTClaimSet()
-
-    // Create the payload as Base64UrlNoPadding
-    val payloadJson = claimsSet.toString()
-    val payloadBase64 = base64UrlNoPadding.encode(payloadJson.encodeToByteArray())
-    val payload = Base64UrlNoPadding.invoke(payloadBase64).getOrThrow()
-
-    // Create signatures for each signer
-    val signatures = signers.map { signer ->
-        // Create a SignedJWT for this signer
-        val header = with(JWSHeader.Builder(signer.alg)) {
-            type(JOSEObjectType(OpenId4VPSpec.AUTHORIZATION_REQUEST_OBJECT_TYPE))
-            signer.headerCustomization(this)
-            build()
-        }
-
-        // Sign the JWT
-        val jwt = SignedJWT(header, claimsSet).apply {
-            val jwsSigner = DefaultJWSSignerFactory().createJWSSigner(signer.key, signer.alg)
-            sign(jwsSigner)
-        }
-
-        // Extract the parts from the signed JWT
-        val parts = jwt.serialize().split(".")
-        val protectedHeader = Base64UrlNoPadding(parts[0]).getOrThrow()
-        val signature = Base64UrlNoPadding(parts[2]).getOrThrow()
-
-        // Create a Signature object
-        Signature(protected = protectedHeader, signature = signature)
-    }
-
-    // Create a JwsJson.General object with the payload and signatures
-    val jwsJson = JwsJson.General(payload = payload, signatures = signatures)
-
-    // Return a ReceivedRequest.Signed with the JwsJson.General object
-    return ReceivedRequest.MultiSigned(jwsJson)
-}
-
-private class SchemeSigner(
-    val alg: JWSAlgorithm,
-    val key: JWK,
-    val headerCustomization: (JWSHeader.Builder).() -> Unit,
-)
-
-private fun UnvalidatedRequestObject.toJWTClaimSet(): JWTClaimsSet {
-    val json = Json.encodeToString(this)
-    return JWTClaimsSet.parse(json)
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcherTest.kt
@@ -25,6 +25,7 @@ import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import eu.europa.ec.eudi.openid4vp.*
+import eu.europa.ec.eudi.openid4vp.internal.JwsJson.Companion.flatten
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
@@ -186,7 +187,7 @@ internal class RequestFetcherTest {
 
 private fun config(clientId: String, jarEncryptionRequirement: EncryptionRequirement): OpenId4VPConfig =
     OpenId4VPConfig(
-        jarConfiguration = JarConfiguration(
+        signedRequestConfiguration = SignedRequestConfiguration(
             supportedAlgorithms = JWSAlgorithm.Family.EC.toList() - JWSAlgorithm.ES256K,
             supportedRequestUriMethods = SupportedRequestUriMethods.Post(
                 includeWalletMetadata = true,
@@ -287,4 +288,9 @@ private fun MockEngine(
         val walletNonce = assertIs<String>(body.formData[OpenId4VPSpec.WALLET_NONCE])
 
         handler(encryptionKey, walletNonce)
+    }
+
+internal fun ReceivedRequest.Signed.toSignedJwts(): List<SignedJWT> =
+    jwsJson.flatten().map {
+        SignedJWT.parse("${it.protected}.${it.payload}.${it.signature}")
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
@@ -41,8 +41,8 @@ class WalletMetaDataTest {
                     ),
                 ),
             ),
-            jarConfiguration = JarConfiguration(
-                supportedAlgorithms = JarConfiguration.Default.supportedAlgorithms,
+            signedRequestConfiguration = SignedRequestConfiguration(
+                supportedAlgorithms = SignedRequestConfiguration.Default.supportedAlgorithms,
                 supportedRequestUriMethods = SupportedRequestUriMethods.Post(
                     jarEncryption = EncryptionRequirement.Required(
                         supportedEncryptionAlgorithms = EncryptionRequirement.Required.SUPPORTED_ENCRYPTION_ALGORITHMS,
@@ -68,8 +68,8 @@ class WalletMetaDataTest {
                     ),
                 ),
             ),
-            jarConfiguration = JarConfiguration(
-                supportedAlgorithms = JarConfiguration.Default.supportedAlgorithms,
+            signedRequestConfiguration = SignedRequestConfiguration(
+                supportedAlgorithms = SignedRequestConfiguration.Default.supportedAlgorithms,
                 supportedRequestUriMethods = SupportedRequestUriMethods.Get,
             ),
         )
@@ -108,7 +108,7 @@ class WalletMetaDataTest {
 
 private suspend fun assertMetadata(config: OpenId4VPConfig, clientId: String) {
     val (encryptionRequirement, ephemeralJarEncryptionJwks) =
-        config.jarConfiguration.supportedRequestUriMethods.isPostSupported()
+        config.signedRequestConfiguration.supportedRequestUriMethods.isPostSupported()
             ?.let { requestUriMethodPost ->
                 when (val jarEncryption = requestUriMethodPost.jarEncryption) {
                     EncryptionRequirement.NotRequired -> jarEncryption to null
@@ -130,7 +130,7 @@ private suspend fun assertMetadata(config: OpenId4VPConfig, clientId: String) {
 }
 
 private fun assertJarSigning(config: OpenId4VPConfig, clientId: String, walletMetaData: JsonObject) {
-    val supportedAlgorithms = config.jarConfiguration.supportedAlgorithms
+    val supportedAlgorithms = config.signedRequestConfiguration.supportedAlgorithms
     val permitsSignedRequestObjects = VerifierId.parse(clientId).getOrNull()?.prefix?.permitsSignedRequestObjects() ?: false
     val algs = walletMetaData["request_object_signing_alg_values_supported"]
     if (permitsSignedRequestObjects) {

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponseDispatcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/AuthorizationResponseDispatcherTest.kt
@@ -177,7 +177,7 @@ class AuthorizationResponseDispatcherTest {
                     }
                 }
 
-                val dispatcher = DefaultDispatcher(managedHttpClient)
+                val dispatcher = DefaultDispatcherOverHttp(managedHttpClient)
                 val outcome = dispatcher.dispatch(
                     openId4VPAuthRequestObject,
                     vpTokenConsensus,
@@ -236,7 +236,7 @@ class AuthorizationResponseDispatcherTest {
                         }
                     }
 
-                    val dispatcher = DefaultDispatcher(managedHttpClient)
+                    val dispatcher = DefaultDispatcherOverHttp(managedHttpClient)
                     val outcome = dispatcher.dispatchError(
                         RequestValidationError.InvalidClientId,
                         errorDispatchDetails,
@@ -301,7 +301,7 @@ class AuthorizationResponseDispatcherTest {
                         }
                     }
 
-                    val dispatcher = DefaultDispatcher(managedHttpClient)
+                    val dispatcher = DefaultDispatcherOverHttp(managedHttpClient)
                     val outcome = dispatcher.dispatchError(
                         RequestValidationError.InvalidRequestUriMethod,
                         errorDispatchDetails,
@@ -334,7 +334,7 @@ class AuthorizationResponseDispatcherTest {
                         }
                     }
 
-                    val dispatcher = DefaultDispatcher(managedHttpClient)
+                    val dispatcher = DefaultDispatcherOverHttp(managedHttpClient)
                     val outcome = dispatcher.dispatchError(
                         RequestValidationError.MissingResponseType,
                         errorDispatchDetails,
@@ -377,7 +377,7 @@ class AuthorizationResponseDispatcherTest {
                         }
                     }
 
-                    val dispatcher = DefaultDispatcher(managedHttpClient)
+                    val dispatcher = DefaultDispatcherOverHttp(managedHttpClient)
                     val outcome = dispatcher.dispatchError(
                         MissingScope,
                         errorDispatchDetails,
@@ -415,7 +415,7 @@ class AuthorizationResponseDispatcherTest {
                         }
                     }
 
-                    val dispatcher = DefaultDispatcher(managedHttpClient)
+                    val dispatcher = DefaultDispatcherOverHttp(managedHttpClient)
                     val outcome = dispatcher.dispatchError(
                         MissingResponseType,
                         errorDispatchDetails,
@@ -457,7 +457,7 @@ class AuthorizationResponseDispatcherTest {
                         }
                     }
 
-                    val dispatcher = DefaultDispatcher(managedHttpClient)
+                    val dispatcher = DefaultDispatcherOverHttp(managedHttpClient)
                     val outcome = dispatcher.dispatchError(
                         RequestValidationError.MissingResponseUri,
                         errorDispatchDetails,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
@@ -33,6 +33,7 @@ import eu.europa.ec.eudi.openid4vp.dcql.*
 import eu.europa.ec.eudi.openid4vp.dcql.ClaimPathElement.Claim
 import eu.europa.ec.eudi.openid4vp.internal.request.ClientMetaDataValidator
 import eu.europa.ec.eudi.openid4vp.internal.request.UnvalidatedClientMetaData
+import eu.europa.ec.eudi.openid4vp.internal.request.ValidatedClientMetaData
 import eu.europa.ec.eudi.openid4vp.internal.request.asHttpsURL
 import eu.europa.ec.eudi.openid4vp.internal.response.DefaultDispatcherTest.Verifier.assertIsJwtEncryptedWithVerifiersPublicKey
 import io.ktor.client.*
@@ -52,6 +53,7 @@ import java.net.URI
 import java.time.Clock
 import kotlin.test.*
 
+@DisplayName("When dispatching OpenId4VP responses")
 class DefaultDispatcherTest {
 
     //
@@ -60,7 +62,9 @@ class DefaultDispatcherTest {
 
     internal object Verifier {
 
-        val CLIENT = Client.Preregistered("https://client.example.org", "Verifier")
+        val CLIENT_ORIGINAL_ID = "https://client.example.org"
+
+        val CLIENT = Client.Preregistered(CLIENT_ORIGINAL_ID, "Verifier")
 
         val responseEncryptionKeyPair: ECKey = ECKeyGenerator(Curve.P_256)
             .keyUse(KeyUse.ENCRYPTION)
@@ -204,7 +208,7 @@ class DefaultDispatcherTest {
     }
 
     @Nested
-    @DisplayName("Encrypted response")
+    @DisplayName("... as an ecrypted direct post (direct_post.jwt)")
     inner class DirectPostJwtResponse {
 
         @Test
@@ -510,36 +514,10 @@ class DefaultDispatcherTest {
                     ),
                 ),
             )
-
-        private fun testCredentialQuery(): CredentialQuery = CredentialQuery(
-            QueryId("my_credential"),
-            Format.SdJwtVc,
-            meta = JsonObject(
-                mapOf(
-                    "vct_values" to
-                        JsonArray(
-                            listOf(
-                                JsonPrimitive("https://credentials.example.com/identity_credential"),
-                            ),
-                        ),
-                ),
-            ),
-            claims = listOf(
-                ClaimsQuery(
-                    path = ClaimPath(listOf(Claim("last_name"))),
-                ),
-                ClaimsQuery(
-                    path = ClaimPath(listOf(Claim("first_name"))),
-                ),
-                ClaimsQuery(
-                    path = ClaimPath(listOf(Claim("address"), Claim("street_address"))),
-                ),
-            ),
-        )
     }
 
     @Nested
-    @DisplayName("In query response")
+    @DisplayName("... as url query param")
     inner class QueryResponse {
 
         private val redirectUriBase = URI("https://foo.bar")
@@ -671,7 +649,7 @@ class DefaultDispatcherTest {
     }
 
     @Nested
-    @DisplayName("In fragment response")
+    @DisplayName("... as url fragment")
     inner class FragmentResponse {
 
         private val redirectUriBase = URI("https://foo.bar")
@@ -811,6 +789,178 @@ class DefaultDispatcherTest {
             map.also(assertions)
         }
     }
+
+    @Nested
+    @DisplayName("... via DC API")
+    inner class DcApiResponse {
+
+        private fun createResolvedRequestObject(
+            validatedClientMetaData: ValidatedClientMetaData?,
+            query: DCQL,
+            state: String,
+            responseMode: ResponseMode,
+        ): ResolvedRequestObject {
+            return ResolvedRequestObject(
+                client = Client.Origin(Verifier.CLIENT_ORIGINAL_ID),
+                query = query,
+                vpFormatsSupported = VpFormatsSupported(
+                    msoMdoc = VpFormatsSupported.MsoMdoc(
+                        issuerAuthAlgorithms = listOf(CoseAlgorithm(-7)),
+                        deviceAuthAlgorithms = listOf(CoseAlgorithm(-7)),
+                    ),
+                ),
+                nonce = "0S6_WzA2Mj",
+                responseMode = responseMode,
+                state = state,
+                responseEncryptionSpecification = validatedClientMetaData?.responseEncryptionSpecification,
+                transactionData = null,
+                verifierInfo = null,
+            )
+        }
+
+        @Test
+        fun `if response mode is dc_api, positive consensus is assembled as vp_token JsonObject`() = runTest {
+            val dcApiDispatcher = DefaultDispatcherOverDCApi()
+
+            val state = genState()
+
+            val query = DCQL(
+                credentials = Credentials(testCredentialQuery()),
+            )
+
+            val resolvedRequestObject = createResolvedRequestObject(
+                validatedClientMetaData = null,
+                query = query,
+                state = state,
+                responseMode = ResponseMode.DCApi,
+            )
+
+            val consensus = Consensus.PositiveConsensus(
+                VerifiablePresentations(
+                    mapOf(
+                        QueryId("my_credential") to listOf(VerifiablePresentation.Generic("dummy_vp_token")),
+                    ),
+                ),
+            )
+
+            val dcApiResponse = dcApiDispatcher.assembleResponse(resolvedRequestObject, consensus)
+
+            val vpToken = dcApiResponse.get("vp_token")
+            assertNotNull(vpToken)
+            assertIs<JsonObject>(vpToken)
+
+            val queryIdResponse = vpToken.get("my_credential")
+            assertNotNull(queryIdResponse)
+            assertIs<JsonArray>(queryIdResponse)
+
+            val stateInResponse = dcApiResponse.get("state")
+            assertNotNull(stateInResponse)
+            assertIs<JsonPrimitive>(stateInResponse)
+            assertEquals(state, stateInResponse.content)
+        }
+
+        @Test
+        fun `if response mode is dc_api jwt, positive consensus is assembled as an encrypted response embedded in JsonObject`() = runTest {
+            val dcApiDispatcher = DefaultDispatcherOverDCApi()
+
+            val state = genState()
+
+            val query = DCQL(
+                credentials = Credentials(testCredentialQuery()),
+            )
+
+            val clientMetadataValidated =
+                ClientMetaDataValidator.validateClientMetaData(
+                    Verifier.metaDataRequestingEncryptedResponse,
+                    ResponseMode.DCApiJwt,
+                    query,
+                    Wallet.config.responseEncryptionConfiguration,
+                    Wallet.config.vpConfiguration.vpFormatsSupported,
+                )
+
+            val resolvedRequestObject = createResolvedRequestObject(
+                validatedClientMetaData = clientMetadataValidated,
+                query = query,
+                state = state,
+                responseMode = ResponseMode.DCApiJwt,
+            )
+
+            val consensus = Consensus.PositiveConsensus(
+                VerifiablePresentations(
+                    mapOf(
+                        QueryId("my_credential") to listOf(VerifiablePresentation.Generic("dummy_vp_token")),
+                    ),
+                ),
+            )
+
+            val apu = "dummy_apu"
+            val dcApiResponse = dcApiDispatcher.assembleResponse(
+                resolvedRequestObject,
+                consensus,
+                EncryptionParameters.DiffieHellman(Base64URL.encode(apu)),
+            )
+
+            val response = dcApiResponse.get("response")
+            assertNotNull(response)
+            assertIs<JsonPrimitive>(response)
+
+            val encryptedResponse = response.content.assertIsJwtEncryptedWithVerifiersPublicKey()
+            assertEquals(Base64URL.encode(resolvedRequestObject.nonce), encryptedResponse.header.agreementPartyVInfo)
+            assertEquals(Base64URL.encode(apu), encryptedResponse.header.agreementPartyUInfo)
+
+            val vpTokenJO = encryptedResponse.jwtClaimsSet.getJSONObjectClaim("vp_token")
+            assertNotNull(vpTokenJO)
+
+            val queryIdResponse = vpTokenJO.get("my_credential")
+            assertNotNull(queryIdResponse)
+            assertIs<List<String>>(queryIdResponse)
+
+            val stateInResponse = encryptedResponse.jwtClaimsSet.getStringClaim("state")
+            assertNotNull(stateInResponse)
+            assertEquals(state, stateInResponse)
+        }
+
+        @Test
+        fun `if response dc_api, negative consensus is assembled as JsonObject`() = runTest {
+            val dcApiDispatcher = DefaultDispatcherOverDCApi()
+
+            val state = genState()
+
+            val query = DCQL(
+                credentials = Credentials(testCredentialQuery()),
+            )
+
+            val resolvedRequestObject = createResolvedRequestObject(
+                validatedClientMetaData = null,
+                query = query,
+                state = state,
+                responseMode = ResponseMode.DCApi,
+            )
+
+            val dcApiResponse = dcApiDispatcher.assembleResponse(resolvedRequestObject, Consensus.NegativeConsensus)
+            val error = dcApiResponse.get("error")
+            assertNotNull(error)
+            assertIs<JsonPrimitive>(error)
+            assertEquals("access_denied", error.content)
+
+            val stateInResponse = dcApiResponse.get("state")
+            assertNotNull(stateInResponse)
+            assertIs<JsonPrimitive>(stateInResponse)
+            assertEquals(state, stateInResponse.content)
+        }
+
+        @Test
+        fun `dc api errors are assembled as json objects`() {
+            val dcApiDispatcher = DefaultDispatcherOverDCApi()
+            val validationError = RequestValidationError.UnexpectedOrigin
+            val errorResponse = dcApiDispatcher.assembleErrorResponse(validationError)
+
+            val error = errorResponse.get("error")
+            assertNotNull(error)
+            assertIs<JsonPrimitive>(error)
+            assertEquals("invalid_request", error.content)
+        }
+    }
 }
 
 private fun genState(): String = State().value
@@ -819,3 +969,29 @@ private fun JWTClaimsSet.vpTokenClaim(): JsonElement? =
 
 private fun URI.getQueryParameter(name: String): String? =
     rawQuery.parseUrlEncodedParameters().toMap().mapValues { it.value.first() }[name]
+
+private fun testCredentialQuery(): CredentialQuery = CredentialQuery(
+    QueryId("my_credential"),
+    Format.SdJwtVc,
+    meta = JsonObject(
+        mapOf(
+            "vct_values" to
+                JsonArray(
+                    listOf(
+                        JsonPrimitive("https://credentials.example.com/identity_credential"),
+                    ),
+                ),
+        ),
+    ),
+    claims = listOf(
+        ClaimsQuery(
+            path = ClaimPath(listOf(Claim("last_name"))),
+        ),
+        ClaimsQuery(
+            path = ClaimPath(listOf(Claim("first_name"))),
+        ),
+        ClaimsQuery(
+            path = ClaimPath(listOf(Claim("address"), Claim("street_address"))),
+        ),
+    ),
+)

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
@@ -155,7 +155,7 @@ class DefaultDispatcherTest {
         )
 
         /**
-         * Creates a [Dispatcher] that mocks the behavior of a Verifier, in case of posting
+         * Creates a [DispatcherOverHttp] that mocks the behavior of a Verifier, in case of posting
          * an authorization response (direct post, or direct post jwt response_mode).
          *
          * The verifier asserts that it receives an HTTP Post, which contains [FormDataContent], having
@@ -168,7 +168,7 @@ class DefaultDispatcherTest {
         fun createDispatcherWithVerifierAsserting(
             responseBodyRedirectUri: URI? = null,
             responseParameterAssertions: (String) -> Unit,
-        ): Dispatcher {
+        ): DispatcherOverHttp {
             val mockEngine = MockEngine { request ->
                 assertEquals(HttpMethod.Post, request.method)
                 request.body.contentType?.let {
@@ -199,7 +199,7 @@ class DefaultDispatcherTest {
                 }
             }
 
-            return DefaultDispatcher(httpClient)
+            return DefaultDispatcherOverHttp(httpClient)
         }
     }
 
@@ -388,7 +388,7 @@ class DefaultDispatcherTest {
                     respondOk()
                 }
                 val httpClient = HttpClient(mockEngine)
-                DefaultDispatcher(httpClient)
+                DefaultDispatcherOverHttp(httpClient)
             }
 
             val dispatchOutcome = errorDispatcher.dispatchError(
@@ -597,7 +597,7 @@ class DefaultDispatcherTest {
                     )
 
                     val outcome = HttpClient().use { httpClient ->
-                        val dispatcher = DefaultDispatcher(httpClient)
+                        val dispatcher = DefaultDispatcherOverHttp(httpClient)
                         dispatcher.dispatch(
                             verifierRequest,
                             Consensus.NegativeConsensus,
@@ -730,7 +730,7 @@ class DefaultDispatcherTest {
                     )
 
                     val outcome = HttpClient().use { httpClient ->
-                        val dispatcher = DefaultDispatcher(httpClient)
+                        val dispatcher = DefaultDispatcherOverHttp(httpClient)
                         dispatcher.dispatch(
                             verifierRequest,
                             Consensus.NegativeConsensus,


### PR DESCRIPTION
## Overview 
DC-API is handled in library as separate channel of receiving authorization requests and responding with a vp_token. This is reflected on the main entrypoint in the library the `OpenId4Vp` object that now can be constructed via `OpenId4Vp.overHttp()` or `OpenId4Vp.overDcAPI()`. 
A separate set of validations is enabled depending on the 'channel' selected.

1. Configuration updated to express expected behavior in case of multi-signed requests
2. Request resolution and dispatching over DC API 
3. Support multi-signed authorization requests
4. Response assembled as JsonObject. No dispaching performed, caller responsibility to return `vp_token`

## Compliance 

Compliance with [Appendix A](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-openid4vp-over-the-digital-) of OpenId4VP protocol for supporting OpenId4VP over DC-API

| Requirement           | Implementation Detail                                                                                      | Alignment  |
|:----------------------|:-----------------------------------------------------------------------------------------------------------|:-----------| 
| Protocol Identifiers  | Uses openid4vp-v1-unsigned, openid4vp-v1-signed, openid4vp-v1-multisigned.                                 | ✅ Full     |
| Response Modes        | Supports dc_api and dc_api.jwt.                                                                            | ✅ Full     |
| Request Types         | Supports Unsigned, Signed (Compact JWS), and Multi-signed ( General JWS JSON).                             | ✅ Full     |
| Origin Binding        | Requires expected_origins in signed requests and validates against the caller's origin.                    | ✅ Full     |
| Client Authentication | Supports origin: prefixed Client IDs for unsigned requests.                                                | ✅ Full     | 
| Response Audience     | Uses the Origin as the audience (aud) for the response payload via the Origin client type.                 | ✅ Full     |
| Credential Formats    | Correctly uses mso_mdoc and dc+sd-jwt as identifiers.                                                      | ✅ Full     | 
| State Parameter       | specification notes state is not supported; implementation preserves it if present but doesn't require it. | ⚠️ Partial |

Closes #405 